### PR TITLE
Save SSH banner to Transport instead of AuthHandler

### DIFF
--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -59,7 +59,6 @@ class AuthHandler (object):
         self.authenticated = False
         self.auth_event = None
         self.auth_method = ''
-        self.banner = None
         self.password = None
         self.private_key = None
         self.interactive_handler = None
@@ -613,7 +612,7 @@ Error Message: {}
 
     def _parse_userauth_banner(self, m):
         banner = m.get_string()
-        self.banner = banner
+        self.transport.banner = banner
         self._log(INFO, 'Auth banner: {}'.format(banner))
         # who cares.
 

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -403,6 +403,8 @@ class Transport(threading.Thread, ClosingContextManager):
         self.handshake_timeout = 15
         # how long (seconds) to wait for the auth response.
         self.auth_timeout = 30
+        # AuthHandler to save MSG_USERAUTH_BANNER msg here
+        self.banner = None
 
         # server mode:
         self.server_mode = False
@@ -1279,16 +1281,15 @@ class Transport(threading.Thread, ClosingContextManager):
 
     def get_banner(self):
         """
-        Return the banner supplied by the server upon connect. If no banner is
+        Return the banner supplied by the server via MSG_USERAUTH_BANNER, picked
+        up by the auth_handler, saved in the Transport. If no banner is
         supplied, this method returns ``None``.
 
         :returns: server supplied banner (`str`), or ``None``.
 
         .. versionadded:: 1.13
         """
-        if not self.active or (self.auth_handler is None):
-            return None
-        return self.auth_handler.banner
+        return self.banner
 
     def auth_none(self, username):
         """


### PR DESCRIPTION
Even though the AuthHandler fields the MSG_USERAUTH_BANNER message, any
followup authentication will discard the Transport’s AuthHandler, along
with the saved banner.

fixes paramiko/paramiko#432

copied from upstream PR https://github.com/paramiko/paramiko/pull/438