### PR TITLE
fix ed25519 ssh key unpad() when padding not present (not needed)

### DIFF
--- a/paramiko/ed25519key.py
+++ b/paramiko/ed25519key.py
@@ -37,10 +37,12 @@ def unpad(data):
     # really ought to be made constant time (possibly by upstreaming this logic
     # into pyca/cryptography).
     padding_length = six.indexbytes(data, -1)
-    if padding_length > 16:
+    if 0x21 <= padding_length <= 0x71:
+        return data
+    if padding_length > 15:
         raise SSHException("Invalid key")
-    for i in range(1, padding_length + 1):
-        if six.indexbytes(data, -i) != (padding_length - i + 1):
+    for i in range(padding_length):
+        if six.indexbytes(data, i - padding_length) != i + 1:
             raise SSHException("Invalid key")
     return data[:-padding_length]
 


### PR DESCRIPTION
fixes paramiko/paramiko#1306

support up to 15 bytes padding ... should only be up to 7,
but test key has 8 bytes of padding, not sure if realistic

port from https://github.com/paramiko/paramiko/pull/1400