### PR TITLE
avoid deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ notifications:
 
 matrix:
   include:
+    # pypy takes longer, start it first
+    - python: "pypy2.7-7.1.1"
+      env: CRYPTO_VER=2.4.2
+    - python: "pypy3.5-7.0"
+      env: CRYPTO_VER=2.6.1
+
     - python: "2.7"
       env: CRYPTO_VER=1.5.3
     - python: "2.7"
@@ -20,11 +26,14 @@ matrix:
     - python: "3.4"
       env: CRYPTO_VER=2.4.2
     - python: "3.5"
-      env: CRYPTO_VER=2.4.2
+      env: CRYPTO_VER=2.6.1
     - python: "3.6"
+      env: CRYPTO_VER=2.4.2
     - python: "3.7"
+      env: CRYPTO_VER=2.6.1
+
 install:
-  - if [ -n "$CRYPTO_VER" ]; then pip install cryptography==$CRYPTO_VER; fi
+  - pip install cryptography==$CRYPTO_VER
   # Self-install for setup.py-driven deps
   - pip install -e .
   # Dev (doc/test running) requirements

--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -150,9 +150,16 @@ class ECDSAKey(PKey):
 
             pointinfo = msg.get_binary()
             try:
-                self.verifying_key = ec.EllipticCurvePublicKey.from_encoded_point(
-                    self.ecdsa_curve.curve_class(), pointinfo
-                )
+                if hasattr(ec.EllipticCurvePublicKey, 'from_encoded_point'):
+                    key = ec.EllipticCurvePublicKey.from_encoded_point(
+                        self.ecdsa_curve.curve_class(), pointinfo
+                    )
+                    self.verifying_key = key
+                else:
+                    numbers = ec.EllipticCurvePublicNumbers.from_encoded_point(
+                        self.ecdsa_curve.curve_class(), pointinfo
+                    )
+                    self.verifying_key = numbers.public_key(backend=default_backend())
             except ValueError:
                 raise SSHException("Invalid public key")
 

--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -150,12 +150,11 @@ class ECDSAKey(PKey):
 
             pointinfo = msg.get_binary()
             try:
-                numbers = ec.EllipticCurvePublicNumbers.from_encoded_point(
+                self.verifying_key = ec.EllipticCurvePublicKey.from_encoded_point(
                     self.ecdsa_curve.curve_class(), pointinfo
                 )
             except ValueError:
                 raise SSHException("Invalid public key")
-            self.verifying_key = numbers.public_key(backend=default_backend())
 
     @classmethod
     def supported_key_format_identifiers(cls):

--- a/paramiko/kex_ecdh_nist.py
+++ b/paramiko/kex_ecdh_nist.py
@@ -15,6 +15,24 @@ from binascii import hexlify
 _MSG_KEXECDH_INIT, _MSG_KEXECDH_REPLY = range(30, 32)
 c_MSG_KEXECDH_INIT, c_MSG_KEXECDH_REPLY = [byte_chr(c) for c in range(30, 32)]
 
+# cryptography >=2.5 vs <2.5
+
+if hasattr(serialization.Encoding, 'X962'):
+    def _ecdh_public_bytes(key):
+        return key.public_bytes(serialization.Encoding.X962,
+                                serialization.PublicFormat.UncompressedPoint)
+else:
+    def _ecdh_public_bytes(key):
+        return key.public_numbers().encode_point()
+
+if hasattr(ec.EllipticCurvePublicKey, 'from_encoded_point'):
+    def _ecdh_from_encoded_point(curve, data):
+        return ec.EllipticCurvePublicKey.from_encoded_point(curve, data)
+else:
+    def _ecdh_from_encoded_point(curve, data):
+        pn = ec.EllipticCurvePublicNumbers.from_encoded_point(curve, data)
+        return pn.public_key(default_backend())
+
 
 class KexNistp256():
 
@@ -37,12 +55,7 @@ class KexNistp256():
         m = Message()
         m.add_byte(c_MSG_KEXECDH_INIT)
         # SEC1: V2.0  2.3.3 Elliptic-Curve-Point-to-Octet-String Conversion
-        m.add_string(
-            self.Q_C.public_bytes(
-                serialization.Encoding.X962,
-                serialization.PublicFormat.UncompressedPoint,
-            )
-        )
+        m.add_string(_ecdh_public_bytes(self.Q_C))
         self.transport._send_message(m)
         self.transport._expect_packet(_MSG_KEXECDH_REPLY)
 
@@ -64,7 +77,7 @@ class KexNistp256():
 
     def _parse_kexecdh_init(self, m):
         Q_C_bytes = m.get_string()
-        self.Q_C = ec.EllipticCurvePublicKey.from_encoded_point(
+        self.Q_C = _ecdh_from_encoded_point(
             self.curve, Q_C_bytes
         )
         K_S = self.transport.get_server_key().asbytes()
@@ -77,12 +90,8 @@ class KexNistp256():
         hm.add_string(K_S)
         hm.add_string(Q_C_bytes)
         # SEC1: V2.0  2.3.3 Elliptic-Curve-Point-to-Octet-String Conversion
-        hm.add_string(
-            self.Q_S.public_bytes(
-                serialization.Encoding.X962,
-                serialization.PublicFormat.UncompressedPoint,
-            )
-        )
+        Q_S_bytes = _ecdh_public_bytes(self.Q_S)
+        hm.add_string(Q_S_bytes)
         hm.add_mpint(long(K))
         H = self.hash_algo(hm.asbytes()).digest()
         self.transport._set_K_H(K, H)
@@ -91,12 +100,7 @@ class KexNistp256():
         m = Message()
         m.add_byte(c_MSG_KEXECDH_REPLY)
         m.add_string(K_S)
-        m.add_string(
-            self.Q_S.public_bytes(
-                serialization.Encoding.X962,
-                serialization.PublicFormat.UncompressedPoint,
-            )
-        )
+        m.add_string(Q_S_bytes)
         m.add_string(sig)
         self.transport._send_message(m)
         self.transport._activate_outbound()
@@ -104,7 +108,7 @@ class KexNistp256():
     def _parse_kexecdh_reply(self, m):
         K_S = m.get_string()
         Q_S_bytes = m.get_string()
-        self.Q_S = ec.EllipticCurvePublicKey.from_encoded_point(
+        self.Q_S = _ecdh_from_encoded_point(
             self.curve, Q_S_bytes
         )
         sig = m.get_binary()
@@ -116,12 +120,7 @@ class KexNistp256():
                self.transport.local_kex_init, self.transport.remote_kex_init)
         hm.add_string(K_S)
         # SEC1: V2.0  2.3.3 Elliptic-Curve-Point-to-Octet-String Conversion
-        hm.add_string(
-            self.Q_C.public_bytes(
-                serialization.Encoding.X962,
-                serialization.PublicFormat.UncompressedPoint,
-            )
-        )
+        hm.add_string(_ecdh_public_bytes(self.Q_C))
         hm.add_string(Q_S_bytes)
         hm.add_mpint(K)
         self.transport._set_K_H(K, self.hash_algo(hm.asbytes()).digest())

--- a/paramiko/kex_ecdh_nist.py
+++ b/paramiko/kex_ecdh_nist.py
@@ -9,6 +9,7 @@ from paramiko.py3compat import byte_chr, long
 from paramiko.ssh_exception import SSHException
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives import serialization
 from binascii import hexlify
 
 _MSG_KEXECDH_INIT, _MSG_KEXECDH_REPLY = range(30, 32)
@@ -36,7 +37,12 @@ class KexNistp256():
         m = Message()
         m.add_byte(c_MSG_KEXECDH_INIT)
         # SEC1: V2.0  2.3.3 Elliptic-Curve-Point-to-Octet-String Conversion
-        m.add_string(self.Q_C.public_numbers().encode_point())
+        m.add_string(
+            self.Q_C.public_bytes(
+                serialization.Encoding.X962,
+                serialization.PublicFormat.UncompressedPoint,
+            )
+        )
         self.transport._send_message(m)
         self.transport._expect_packet(_MSG_KEXECDH_REPLY)
 
@@ -58,11 +64,11 @@ class KexNistp256():
 
     def _parse_kexecdh_init(self, m):
         Q_C_bytes = m.get_string()
-        self.Q_C = ec.EllipticCurvePublicNumbers.from_encoded_point(
+        self.Q_C = ec.EllipticCurvePublicKey.from_encoded_point(
             self.curve, Q_C_bytes
         )
         K_S = self.transport.get_server_key().asbytes()
-        K = self.P.exchange(ec.ECDH(), self.Q_C.public_key(default_backend()))
+        K = self.P.exchange(ec.ECDH(), self.Q_C)
         K = long(hexlify(K), 16)
         # compute exchange hash
         hm = Message()
@@ -71,7 +77,12 @@ class KexNistp256():
         hm.add_string(K_S)
         hm.add_string(Q_C_bytes)
         # SEC1: V2.0  2.3.3 Elliptic-Curve-Point-to-Octet-String Conversion
-        hm.add_string(self.Q_S.public_numbers().encode_point())
+        hm.add_string(
+            self.Q_S.public_bytes(
+                serialization.Encoding.X962,
+                serialization.PublicFormat.UncompressedPoint,
+            )
+        )
         hm.add_mpint(long(K))
         H = self.hash_algo(hm.asbytes()).digest()
         self.transport._set_K_H(K, H)
@@ -80,7 +91,12 @@ class KexNistp256():
         m = Message()
         m.add_byte(c_MSG_KEXECDH_REPLY)
         m.add_string(K_S)
-        m.add_string(self.Q_S.public_numbers().encode_point())
+        m.add_string(
+            self.Q_S.public_bytes(
+                serialization.Encoding.X962,
+                serialization.PublicFormat.UncompressedPoint,
+            )
+        )
         m.add_string(sig)
         self.transport._send_message(m)
         self.transport._activate_outbound()
@@ -88,11 +104,11 @@ class KexNistp256():
     def _parse_kexecdh_reply(self, m):
         K_S = m.get_string()
         Q_S_bytes = m.get_string()
-        self.Q_S = ec.EllipticCurvePublicNumbers.from_encoded_point(
+        self.Q_S = ec.EllipticCurvePublicKey.from_encoded_point(
             self.curve, Q_S_bytes
         )
         sig = m.get_binary()
-        K = self.P.exchange(ec.ECDH(), self.Q_S.public_key(default_backend()))
+        K = self.P.exchange(ec.ECDH(), self.Q_S)
         K = long(hexlify(K), 16)
         # compute exchange hash and verify signature
         hm = Message()
@@ -100,7 +116,12 @@ class KexNistp256():
                self.transport.local_kex_init, self.transport.remote_kex_init)
         hm.add_string(K_S)
         # SEC1: V2.0  2.3.3 Elliptic-Curve-Point-to-Octet-String Conversion
-        hm.add_string(self.Q_C.public_numbers().encode_point())
+        hm.add_string(
+            self.Q_C.public_bytes(
+                serialization.Encoding.X962,
+                serialization.PublicFormat.UncompressedPoint,
+            )
+        )
         hm.add_string(Q_S_bytes)
         hm.add_mpint(K)
         self.transport._set_K_H(K, self.hash_algo(hm.asbytes()).digest())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -363,13 +363,13 @@ class SSHClientTest(ClientTest):
         os.close(fd)
 
         client = paramiko.SSHClient()
-        self.assertEquals(0, len(client.get_host_keys()))
+        self.assertEqual(0, len(client.get_host_keys()))
 
         host_id = '[%s]:%d' % (self.addr, self.port)
 
         client.get_host_keys().add(host_id, 'ssh-rsa', public_host_key)
-        self.assertEquals(1, len(client.get_host_keys()))
-        self.assertEquals(public_host_key, client.get_host_keys()[host_id]['ssh-rsa'])
+        self.assertEqual(1, len(client.get_host_keys()))
+        self.assertEqual(public_host_key, client.get_host_keys()[host_id]['ssh-rsa'])
 
         client.save_host_keys(localname)
 
@@ -420,7 +420,7 @@ class SSHClientTest(ClientTest):
         with paramiko.SSHClient() as tc:
             self.tc = tc
             self.tc.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            self.assertEquals(0, len(self.tc.get_host_keys()))
+            self.assertEqual(0, len(self.tc.get_host_keys()))
             self.tc.connect(**dict(self.connect_kwargs, password='pygmalion'))
 
             self.event.wait(1.0)

--- a/tests/test_gssapi.py
+++ b/tests/test_gssapi.py
@@ -45,7 +45,7 @@ class GSSAPITest(unittest.TestCase):
         from pyasn1.codec.der import encoder, decoder
         oid = encoder.encode(ObjectIdentifier(self.krb5_mech))
         mech, __ = decoder.decode(oid)
-        self.assertEquals(self.krb5_mech, mech.__str__())
+        self.assertEqual(self.krb5_mech, mech.__str__())
 
     def test_2_gssapi_sspi(self):
         """
@@ -85,27 +85,27 @@ class GSSAPITest(unittest.TestCase):
             if self.server_mode:
                 c_token = gss_ctxt.step(c_token)
                 gss_ctxt_status = gss_ctxt.established
-                self.assertEquals(False, gss_ctxt_status)
+                self.assertEqual(False, gss_ctxt_status)
                 # Accept a GSS-API context.
                 gss_srv_ctxt = gssapi.AcceptContext()
                 s_token = gss_srv_ctxt.step(c_token)
                 gss_ctxt_status = gss_srv_ctxt.established
-                self.assertNotEquals(None, s_token)
-                self.assertEquals(True, gss_ctxt_status)
+                self.assertNotEqual(None, s_token)
+                self.assertEqual(True, gss_ctxt_status)
                 # Establish the client context
                 c_token = gss_ctxt.step(s_token)
-                self.assertEquals(None, c_token)
+                self.assertEqual(None, c_token)
             else:
                 while not gss_ctxt.established:
                     c_token = gss_ctxt.step(c_token)
-                self.assertNotEquals(None, c_token)
+                self.assertNotEqual(None, c_token)
             # Build MIC
             mic_token = gss_ctxt.get_mic(mic_msg)
 
             if self.server_mode:
                 # Check MIC
                 status = gss_srv_ctxt.verify_mic(mic_msg, mic_token)
-                self.assertEquals(0, status)
+                self.assertEqual(0, status)
         else:
             gss_flags = (
                 sspicon.ISC_REQ_INTEGRITY |
@@ -120,7 +120,7 @@ class GSSAPITest(unittest.TestCase):
             if self.server_mode:
                 error, token = gss_ctxt.authorize(c_token)
                 c_token = token[0].Buffer
-                self.assertEquals(0, error)
+                self.assertEqual(0, error)
                 # Accept a GSS-API context.
                 gss_srv_ctxt = sspi.ServerAuth("Kerberos", spn=target_name)
                 error, token = gss_srv_ctxt.authorize(c_token)
@@ -128,8 +128,8 @@ class GSSAPITest(unittest.TestCase):
                 # Establish the context.
                 error, token = gss_ctxt.authorize(s_token)
                 c_token = token[0].Buffer
-                self.assertEquals(None, c_token)
-                self.assertEquals(0, error)
+                self.assertEqual(None, c_token)
+                self.assertEqual(0, error)
                 # Build MIC
                 mic_token = gss_ctxt.sign(mic_msg)
                 # Check MIC
@@ -137,4 +137,4 @@ class GSSAPITest(unittest.TestCase):
             else:
                 error, token = gss_ctxt.authorize(c_token)
                 c_token = token[0].Buffer
-                self.assertNotEquals(0, error)
+                self.assertNotEqual(0, error)

--- a/tests/test_kex.py
+++ b/tests/test_kex.py
@@ -41,12 +41,20 @@ def dummy_urandom(n):
 def dummy_generate_key_pair(obj):
     private_key_value = 94761803665136558137557783047955027733968423115106677159790289642479432803037
     public_key_numbers = "042bdab212fa8ba1b7c843301682a4db424d307246c7e1e6083c41d9ca7b098bf30b3d63e2ec6278488c135360456cc054b3444ecc45998c08894cbc1370f5f989"
-    public_key_numbers_obj = ec.EllipticCurvePublicNumbers.from_encoded_point(ec.SECP256R1(), unhexlify(public_key_numbers))
-    obj.P = ec.EllipticCurvePrivateNumbers(private_value=private_key_value, public_numbers=public_key_numbers_obj).private_key(default_backend())
+    public_key_numbers_obj = ec.EllipticCurvePublicKey.from_encoded_point(
+        ec.SECP256R1(), unhexlify(public_key_numbers)
+    ).public_numbers()
+    obj.P = ec.EllipticCurvePrivateNumbers(
+        private_value=private_key_value, public_numbers=public_key_numbers_obj
+    ).private_key(default_backend())
     if obj.transport.server_mode:
-        obj.Q_S = ec.EllipticCurvePublicNumbers.from_encoded_point(ec.SECP256R1(), unhexlify(public_key_numbers)).public_key(default_backend())
+        obj.Q_S = ec.EllipticCurvePublicKey.from_encoded_point(
+            ec.SECP256R1(), unhexlify(public_key_numbers)
+        )
         return
-    obj.Q_C = ec.EllipticCurvePublicNumbers.from_encoded_point(ec.SECP256R1(), unhexlify(public_key_numbers)).public_key(default_backend())
+    obj.Q_C = ec.EllipticCurvePublicKey.from_encoded_point(
+        ec.SECP256R1(), unhexlify(public_key_numbers)
+    )
 
 
 class FakeKey (object):

--- a/tests/test_kex.py
+++ b/tests/test_kex.py
@@ -32,7 +32,7 @@ from paramiko.kex_group1 import KexGroup1
 from paramiko.kex_gex import KexGex, KexGexSHA256
 from paramiko import Message
 from paramiko.common import byte_chr
-from paramiko.kex_ecdh_nist import KexNistp256
+from paramiko.kex_ecdh_nist import KexNistp256, _ecdh_from_encoded_point
 
 
 def dummy_urandom(n):
@@ -41,18 +41,18 @@ def dummy_urandom(n):
 def dummy_generate_key_pair(obj):
     private_key_value = 94761803665136558137557783047955027733968423115106677159790289642479432803037
     public_key_numbers = "042bdab212fa8ba1b7c843301682a4db424d307246c7e1e6083c41d9ca7b098bf30b3d63e2ec6278488c135360456cc054b3444ecc45998c08894cbc1370f5f989"
-    public_key_numbers_obj = ec.EllipticCurvePublicKey.from_encoded_point(
+    public_key_numbers_obj = _ecdh_from_encoded_point(
         ec.SECP256R1(), unhexlify(public_key_numbers)
     ).public_numbers()
     obj.P = ec.EllipticCurvePrivateNumbers(
         private_value=private_key_value, public_numbers=public_key_numbers_obj
     ).private_key(default_backend())
     if obj.transport.server_mode:
-        obj.Q_S = ec.EllipticCurvePublicKey.from_encoded_point(
+        obj.Q_S = _ecdh_from_encoded_point(
             ec.SECP256R1(), unhexlify(public_key_numbers)
         )
         return
-    obj.Q_C = ec.EllipticCurvePublicKey.from_encoded_point(
+    obj.Q_C = _ecdh_from_encoded_point(
         ec.SECP256R1(), unhexlify(public_key_numbers)
     )
 

--- a/tests/test_kex_gss.py
+++ b/tests/test_kex_gss.py
@@ -114,9 +114,9 @@ class GSSKexTest(unittest.TestCase):
         self.event.wait(1.0)
         self.assert_(self.event.is_set())
         self.assert_(self.ts.is_active())
-        self.assertEquals(self.username, self.ts.get_username())
-        self.assertEquals(True, self.ts.is_authenticated())
-        self.assertEquals(True, self.tc.get_transport().gss_kex_used)
+        self.assertEqual(self.username, self.ts.get_username())
+        self.assertEqual(True, self.ts.is_authenticated())
+        self.assertEqual(True, self.tc.get_transport().gss_kex_used)
 
         stdin, stdout, stderr = self.tc.exec_command('yes')
         schan = self.ts.accept(1.0)
@@ -127,10 +127,10 @@ class GSSKexTest(unittest.TestCase):
         schan.send_stderr('This is on stderr.\n')
         schan.close()
 
-        self.assertEquals('Hello there.\n', stdout.readline())
-        self.assertEquals('', stdout.readline())
-        self.assertEquals('This is on stderr.\n', stderr.readline())
-        self.assertEquals('', stderr.readline())
+        self.assertEqual('Hello there.\n', stdout.readline())
+        self.assertEqual('', stdout.readline())
+        self.assertEqual('This is on stderr.\n', stderr.readline())
+        self.assertEqual('', stderr.readline())
 
         stdin.close()
         stdout.close()

--- a/tests/test_ssh_gss.py
+++ b/tests/test_ssh_gss.py
@@ -116,8 +116,8 @@ class GSSAuthTest(unittest.TestCase):
         self.event.wait(1.0)
         self.assert_(self.event.is_set())
         self.assert_(self.ts.is_active())
-        self.assertEquals(self.username, self.ts.get_username())
-        self.assertEquals(True, self.ts.is_authenticated())
+        self.assertEqual(self.username, self.ts.get_username())
+        self.assertEqual(True, self.ts.is_authenticated())
 
         stdin, stdout, stderr = self.tc.exec_command('yes')
         schan = self.ts.accept(1.0)
@@ -126,10 +126,10 @@ class GSSAuthTest(unittest.TestCase):
         schan.send_stderr('This is on stderr.\n')
         schan.close()
 
-        self.assertEquals('Hello there.\n', stdout.readline())
-        self.assertEquals('', stdout.readline())
-        self.assertEquals('This is on stderr.\n', stderr.readline())
-        self.assertEquals('', stderr.readline())
+        self.assertEqual('Hello there.\n', stdout.readline())
+        self.assertEqual('', stdout.readline())
+        self.assertEqual('This is on stderr.\n', stderr.readline())
+        self.assertEqual('', stderr.readline())
 
         stdin.close()
         stdout.close()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -402,7 +402,7 @@ Host param4 "p a r" "p" "par" para
         f = StringIO(test_config_file)
         config = paramiko.util.parse_ssh_config(f)
         for host, values in res.items():
-            self.assertEquals(
+            self.assertEqual(
                 paramiko.util.lookup_ssh_host_config(host, config),
                 values
             )
@@ -432,7 +432,7 @@ Host param3 parara
         f = StringIO(test_config_file)
         config = paramiko.util.parse_ssh_config(f)
         for host, values in res.items():
-            self.assertEquals(
+            self.assertEqual(
                 paramiko.util.lookup_ssh_host_config(host, config),
                 values
             )
@@ -462,7 +462,7 @@ Host param3 parara
             'param "pam" "p a',
         ]
         for host, values in correct_data.items():
-            self.assertEquals(
+            self.assertEqual(
                 conf._get_hosts(host),
                 values
             )


### PR DESCRIPTION
assertEquals() is long deprecated in favor of assertEqual()

cryptography-2.5+ wants different key bytes functions to be used