### PR TITLE
Removed support for hmac-md5 and truncated hmac-sha1

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -113,7 +113,6 @@ class Transport(threading.Thread, ClosingContextManager):
         'aes128-cbc',
         'aes192-cbc',
         'aes256-cbc',
-        'blowfish-cbc',
         '3des-cbc',
     )
     _preferred_macs = (
@@ -129,7 +128,6 @@ class Transport(threading.Thread, ClosingContextManager):
         'ecdsa-sha2-nistp384',
         'ecdsa-sha2-nistp521',
         'ssh-rsa',
-        'ssh-dss',
     )
     _preferred_kex = (
         'ecdh-sha2-nistp256',

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -28,7 +28,7 @@ import sys
 import threading
 import time
 import weakref
-from hashlib import md5, sha1, sha256, sha512
+from hashlib import sha1, sha256, sha512
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
@@ -122,9 +122,6 @@ class Transport(threading.Thread, ClosingContextManager):
         'hmac-sha2-256-etm@openssh.com',
         'hmac-sha2-512-etm@openssh.com',
         'hmac-sha1',
-        'hmac-md5',
-        'hmac-sha1-96',
-        'hmac-md5-96',
     )
     _preferred_keys = (
         'ssh-ed25519',
@@ -206,13 +203,10 @@ class Transport(threading.Thread, ClosingContextManager):
 
     _mac_info = {
         'hmac-sha1': {'class': sha1, 'size': 20},
-        'hmac-sha1-96': {'class': sha1, 'size': 12},
         'hmac-sha2-256': {'class': sha256, 'size': 32},
         'hmac-sha2-256-etm@openssh.com': {'class': sha256, 'size': 32},
         'hmac-sha2-512': {'class': sha512, 'size': 64},
         'hmac-sha2-512-etm@openssh.com': {'class': sha512, 'size': 64},
-        'hmac-md5': {'class': md5, 'size': 16},
-        'hmac-md5-96': {'class': md5, 'size': 12},
     }
 
     _key_info = {

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -256,12 +256,12 @@ class TransportTest(unittest.TestCase):
         """
         def force_algorithms(options):
             options.ciphers = ('aes256-cbc',)
-            options.digests = ('hmac-md5-96',)
+            options.digests = ('hmac-sha1',)
         self.setup_test_server(client_options=force_algorithms)
         self.assertEqual('aes256-cbc', self.tc.local_cipher)
         self.assertEqual('aes256-cbc', self.tc.remote_cipher)
-        self.assertEqual(12, self.tc.packetizer.get_mac_size_out())
-        self.assertEqual(12, self.tc.packetizer.get_mac_size_in())
+        self.assertEqual(20, self.tc.packetizer.get_mac_size_out())
+        self.assertEqual(20, self.tc.packetizer.get_mac_size_in())
 
         self.tc.send_ignore(1024)
         self.tc.renegotiate_keys()


### PR DESCRIPTION
These are being removed from OpenSSH as well:
https://github.com/openssh/openssh-portable/commit/714e367226ded4dc3897078be48b961637350b05

port of https://github.com/paramiko/paramiko/pull/688