### PR TITLE
sshclient: detect allowed authentication types

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -620,15 +620,15 @@ class SSHClient (ClosingContextManager):
         try:
             self._transport.auth_none(username)
         except BadAuthenticationType as e:
-            allowed_auth_methods = frozenset(e.allowed_types)
+            allowed_types = set(e.allowed_types)
         else:
             return  # successful login with no auth
 
         # some servers do not return allowed auth methods
-        if not allowed_auth_methods:
-            allowed_auth_methods = frozenset(('password', 'publickey'))
+        if not allowed_types:
+            allowed_types = {'password', 'publickey'}
 
-        if pkey is not None and 'publickey' in allowed_auth_methods:
+        if pkey is not None and 'publickey' in allowed_types:
             try:
                 self._log(
                     DEBUG,
@@ -642,7 +642,7 @@ class SSHClient (ClosingContextManager):
             except SSHException as e:
                 saved_exception = e
 
-        if not two_factor and 'publickey' in allowed_auth_methods:
+        if not two_factor and 'publickey' in allowed_types:
             for key_filename in key_filenames:
                 for pkey_class in (RSAKey, DSSKey, ECDSAKey, Ed25519Key):
                     try:
@@ -658,7 +658,7 @@ class SSHClient (ClosingContextManager):
                     except SSHException as e:
                         saved_exception = e
 
-        if not two_factor and allow_agent and 'publickey' in allowed_auth_methods:
+        if allow_agent and not two_factor and 'publickey' in allowed_types:
             if self._agent is None:
                 self._agent = Agent()
 
@@ -666,8 +666,6 @@ class SSHClient (ClosingContextManager):
                 try:
                     id_ = hexlify(key.get_fingerprint())
                     self._log(DEBUG, 'Trying SSH agent key {}'.format(id_))
-                    # for 2-factor auth a successfully auth'd key password
-                    # will return an allowed 2fac auth method
                     allowed_types = set(
                         self._transport.auth_publickey(username, key))
                     two_factor = (allowed_types & two_factor_types)
@@ -677,9 +675,8 @@ class SSHClient (ClosingContextManager):
                 except SSHException as e:
                     saved_exception = e
 
-        if not two_factor and look_for_keys and 'publickey' in allowed_auth_methods:
+        if look_for_keys and not two_factor and 'publickey' in allowed_types:
             keyfiles = []
-
             for keytype, name in [
                 (RSAKey, "rsa"),
                 (DSSKey, "dsa"),
@@ -702,8 +699,6 @@ class SSHClient (ClosingContextManager):
                     key = self._key_from_filepath(
                         filename, pkey_class, passphrase,
                     )
-                    # for 2-factor auth a successfully auth'd key will result
-                    # in ['password']
                     allowed_types = set(
                         self._transport.auth_publickey(username, key))
                     two_factor = (allowed_types & two_factor_types)
@@ -713,14 +708,23 @@ class SSHClient (ClosingContextManager):
                 except (SSHException, IOError) as e:
                     saved_exception = e
 
-        if password is not None and 'password' in allowed_auth_methods:
+        # possible two_factor second factors
+        # (allowed_types could have been updated, only if two_factor)
+
+        if password is not None and 'password' in allowed_types:
             try:
-                self._transport.auth_password(username, password)
-                return
+                self._log(DEBUG, 'Trying password')
+                allowed_types = set(
+                    self._transport.auth_password(username, password))
+                two_factor = allowed_types & two_factor_types
+                if not two_factor:
+                    return
             except SSHException as e:
                 saved_exception = e
-        elif two_factor:
+
+        if 'keyboard-interactive' in allowed_types:
             try:
+                self._log(DEBUG, 'Trying interactive auth')
                 self._transport.auth_interactive_dumb(username)
                 return
             except SSHException as e:

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -38,7 +38,8 @@ from paramiko.hostkeys import HostKeys
 from paramiko.py3compat import string_types
 from paramiko.rsakey import RSAKey
 from paramiko.ssh_exception import (
-    SSHException, BadHostKeyException, NoValidConnectionsError
+    SSHException, BadAuthenticationType, BadHostKeyException,
+    NoValidConnectionsError
 )
 from paramiko.transport import Transport
 from paramiko.util import retry_on_signal, ClosingContextManager
@@ -614,7 +615,20 @@ class SSHClient (ClosingContextManager):
             except Exception as e:
                 saved_exception = e
 
-        if pkey is not None:
+        # detect what authentication methods the server supports
+        # mirrors what openssh client does
+        try:
+            self._transport.auth_none(username)
+        except BadAuthenticationType as e:
+            allowed_auth_methods = frozenset(e.allowed_types)
+        else:
+            return  # successful login with no auth
+
+        # some servers do not return allowed auth methods
+        if not allowed_auth_methods:
+            allowed_auth_methods = frozenset(('password', 'publickey'))
+
+        if pkey is not None and 'publickey' in allowed_auth_methods:
             try:
                 self._log(
                     DEBUG,
@@ -628,7 +642,7 @@ class SSHClient (ClosingContextManager):
             except SSHException as e:
                 saved_exception = e
 
-        if not two_factor:
+        if not two_factor and 'publickey' in allowed_auth_methods:
             for key_filename in key_filenames:
                 for pkey_class in (RSAKey, DSSKey, ECDSAKey, Ed25519Key):
                     try:
@@ -644,7 +658,7 @@ class SSHClient (ClosingContextManager):
                     except SSHException as e:
                         saved_exception = e
 
-        if not two_factor and allow_agent:
+        if not two_factor and allow_agent and 'publickey' in allowed_auth_methods:
             if self._agent is None:
                 self._agent = Agent()
 
@@ -663,7 +677,7 @@ class SSHClient (ClosingContextManager):
                 except SSHException as e:
                     saved_exception = e
 
-        if not two_factor and look_for_keys:
+        if not two_factor and look_for_keys and 'publickey' in allowed_auth_methods:
             keyfiles = []
 
             for keytype, name in [
@@ -699,7 +713,7 @@ class SSHClient (ClosingContextManager):
                 except (SSHException, IOError) as e:
                     saved_exception = e
 
-        if password is not None:
+        if password is not None and 'password' in allowed_auth_methods:
             try:
                 self._transport.auth_password(username, password)
                 return

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1138,9 +1138,10 @@ class Transport(threading.Thread, ClosingContextManager):
         transfer.
 
         .. note::
-            If you fail to supply a password or private key, this method may
-            succeed, but a subsequent `open_channel` or `open_session` call may
-            fail because you haven't authenticated yet.
+            If you do not supply a password or private key, this method may
+            succeed, but a subsequent `open_channel` or `open_session` call
+            will likely fail because you haven't authenticated yet (but you
+            can call auth methods manually after this).
 
         :param .PKey hostkey:
             the host key expected from the server, or ``None`` if you don't
@@ -1204,7 +1205,7 @@ class Transport(threading.Thread, ClosingContextManager):
 
         if (pkey is not None) or (password is not None) or gss_auth or gss_kex:
             if gss_auth:
-                self._log(DEBUG, 'Attempting GSS-API auth... (gssapi-with-mic)') # noqa
+                self._log(DEBUG, 'Attempting GSS-API auth... (gssapi-with-mic)')
                 self.auth_gssapi_with_mic(
                     username, self.gss_host, gss_deleg_creds,
                 )
@@ -1218,6 +1219,7 @@ class Transport(threading.Thread, ClosingContextManager):
                 self._log(DEBUG, 'Attempting password auth...')
                 self.auth_password(username, password)
 
+        # if no auth method supplied, auth not done, caller should do auth now
         return
 
     def get_exception(self):


### PR DESCRIPTION
Some systems are configured to close the connection after one
authentication attempt.  If this is the case and we are provided with

To fix that, we need to detect the allowed authentication methods and
only try public key or password if those are allowed.

Also enables the "no auth" case, used by some appliances, to work.

port of https://github.com/paramiko/paramiko/pull/1106