### PR TITLE
SSHClient: invoke_shell() should use environment argument

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -515,6 +515,8 @@ class SSHClient (ClosingContextManager):
         :raises: `.SSHException` -- if the server fails to invoke a shell
         """
         chan = self._transport.open_session()
+        if environment:
+            chan.update_environment(environment)
         chan.get_pty(term, width, height, width_pixels, height_pixels)
         chan.invoke_shell()
         return chan


### PR DESCRIPTION
previously it was completely ignored

port of https://github.com/paramiko/paramiko/pull/1250