### PR TITLE
demos: Use sendall() instead of send() for port forwarding

### DIFF
--- a/demos/forward.py
+++ b/demos/forward.py
@@ -75,12 +75,12 @@ class Handler (SocketServer.BaseRequestHandler):
                 data = self.request.recv(1024)
                 if len(data) == 0:
                     break
-                chan.send(data)
+                chan.sendall(data)
             if chan in r:
                 data = chan.recv(1024)
                 if len(data) == 0:
                     break
-                self.request.send(data)
+                self.request.sendall(data)
 
         peername = self.request.getpeername()
         chan.close()

--- a/demos/rforward.py
+++ b/demos/rforward.py
@@ -57,12 +57,12 @@ def handler(chan, host, port):
             data = sock.recv(1024)
             if len(data) == 0:
                 break
-            chan.send(data)
+            chan.sendall(data)
         if chan in r:
             data = chan.recv(1024)
             if len(data) == 0:
                 break
-            sock.send(data)
+            sock.sendall(data)
     chan.close()
     sock.close()
     verbose('Tunnel closed from %r' % (chan.origin_addr,))


### PR DESCRIPTION
to avoid losing bytes when send buffer/window fills up

Fixes paramiko/paramiko#511

This fix is not ideal. Since sendall() blocks until all data is sent,
there may be a risk of a deadlock if there is data congestion in both
directions simultaneously. However, the likelihood is significantly
lower than the likelihood of hitting the current bug where bytes are
lost.

port of https://github.com/paramiko/paramiko/pull/1244