### PR TITLE
channel: fileno pipe race fixes

### DIFF
--- a/paramiko/buffered_pipe.py
+++ b/paramiko/buffered_pipe.py
@@ -85,6 +85,16 @@ class BufferedPipe (object):
         finally:
             self._lock.release()
 
+    def unlink_event(self):
+        """
+        Unlink an Event object from this buffer.
+        """
+        self._lock.acquire()
+        try:
+            self._event = None
+        finally:
+            self._lock.release()
+
     def feed(self, data):
         """
         Feed new data into this pipe.  This method is assumed to be called

--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -639,8 +639,11 @@ class Channel (ClosingContextManager):
             # only close the pipe when the user explicitly closes the channel.
             # otherwise they will get unpleasant surprises.  (and do it before
             # checking self.closed, since the remote host may have already
-            # closed the connection.)
+            # closed the connection.); must also unlink the pipe from in_buffer and
+            # in_stderr_buffer to avoid writing to an already closed pipe.
             if self._pipe is not None:
+                self.in_buffer.unlink_event()
+                self.in_stderr_buffer.unlink_event()
                 self._pipe.close()
                 self._pipe = None
 

--- a/paramiko/pipe.py
+++ b/paramiko/pipe.py
@@ -28,6 +28,7 @@ will trigger as readable in `select <select.select>`.
 import sys
 import os
 import socket
+import threading
 
 
 def make_pipe():
@@ -124,14 +125,18 @@ class OrPipe (object):
         self._pipe = pipe
 
     def set(self):
+        self._pipe._lock.acquire()
         self._set = True
         if not self._partner._set:
             self._pipe.set()
+        self._pipe._lock.release()
 
     def clear(self):
+        self._pipe._lock.acquire()
         self._set = False
         if not self._partner._set:
             self._pipe.clear()
+        self._pipe._lock.release()
 
 
 def make_or_pipe(pipe):
@@ -140,6 +145,7 @@ def make_or_pipe(pipe):
     affect the real pipe. if either returned pipe is set, the wrapped pipe
     is set. when both are cleared, the wrapped pipe is cleared.
     """
+    pipe._lock = threading.Lock()
     p1 = OrPipe(pipe)
     p2 = OrPipe(pipe)
     p1._partner = p2


### PR DESCRIPTION
In the context of fileno(), a Channel's .in_buffer and .in_stderr_buffer
operate on a pair of of OrPipes obtained from make_or_pipe(). These two
cooperate and share the same underlying PosixPipe resp. WindowsPipe.

Due to the lack of any synchronization in the OrPipe's .set() method, it
is possible (and has actually been observed) to have both OrPipes'
._set = True while the underlying pipe remains unset.

Fix that by adding proper locking to the OrPipe implementation.

port of https://github.com/paramiko/paramiko/pull/1235

EDIT: added
port of https://github.com/paramiko/paramiko/pull/1158
see also https://github.com/paramiko/paramiko/issues/1157