### PR TITLE
tests: remove numbering from test function names

### DIFF
--- a/tests/test_buffered_pipe.py
+++ b/tests/test_buffered_pipe.py
@@ -41,7 +41,7 @@ def close_thread(p):
 
 
 class BufferedPipeTest(unittest.TestCase):
-    def test_1_buffered_pipe(self):
+    def test_buffered_pipe(self):
         p = BufferedPipe()
         self.assertTrue(not p.read_ready())
         p.feed('hello.')
@@ -58,7 +58,7 @@ class BufferedPipeTest(unittest.TestCase):
         self.assertTrue(not p.read_ready())
         self.assertEqual(b'', p.read(1))
 
-    def test_2_delay(self):
+    def test_delay(self):
         p = BufferedPipe()
         self.assertTrue(not p.read_ready())
         threading.Thread(target=delay_thread, args=(p,)).start()
@@ -71,13 +71,13 @@ class BufferedPipeTest(unittest.TestCase):
         self.assertEqual(b'b', p.read(1, 1.0))
         self.assertEqual(b'', p.read(1))
 
-    def test_3_close_while_reading(self):
+    def test_close_while_reading(self):
         p = BufferedPipe()
         threading.Thread(target=close_thread, args=(p,)).start()
         data = p.read(1, 1.0)
         self.assertEqual(b'', data)
 
-    def test_4_or_pipe(self):
+    def test_or_pipe(self):
         p = pipe.make_pipe()
         p1, p2 = pipe.make_or_pipe(p)
         self.assertFalse(p._set)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -22,7 +22,6 @@ Some unit tests for SSHClient.
 
 import gc
 import os
-import platform
 import socket
 import threading
 import time
@@ -389,10 +388,6 @@ class SSHClientTest(ClientTest):
         verify that when an SSHClient is collected, its transport (and the
         transport's packetizer) is closed.
         """
-        # Skipped on PyPy because it fails on travis for unknown reasons
-        if platform.python_implementation() == "PyPy":
-            return
-
         threading.Thread(target=self._run).start()
 
         self.tc = paramiko.SSHClient()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -222,13 +222,13 @@ class ClientTest(unittest.TestCase):
 
 
 class SSHClientTest(ClientTest):
-    def test_1_client(self):
+    def test_client(self):
         """
         verify that the SSHClient stuff works too.
         """
         self._test_connection(password='pygmalion')
 
-    def test_2_client_dsa(self):
+    def test_client_dsa(self):
         """
         verify that SSHClient works with a DSA key.
         """
@@ -240,7 +240,7 @@ class SSHClientTest(ClientTest):
         """
         self._test_connection(key_filename=_support('test_rsa.key'))
 
-    def test_2_5_client_ecdsa(self):
+    def test_client_ecdsa(self):
         """
         verify that SSHClient works with an ECDSA key.
         """
@@ -250,7 +250,7 @@ class SSHClientTest(ClientTest):
     def test_client_ed25519(self):
         self._test_connection(key_filename=_support('test_ed25519.key'))
 
-    def test_3_multiple_key_files(self):
+    def test_multiple_key_files(self):
         """
         verify that SSHClient accepts and tries multiple key files.
         """
@@ -334,7 +334,7 @@ class SSHClientTest(ClientTest):
         # code path (!) so we're punting too, sob.
         pass
 
-    def test_4_auto_add_policy(self):
+    def test_auto_add_policy(self):
         """
         verify that SSHClient's AutoAddPolicy works.
         """
@@ -357,7 +357,7 @@ class SSHClientTest(ClientTest):
         new_host_key = list(self.tc.get_host_keys()[hostname].values())[0]
         self.assertEqual(public_host_key, new_host_key)
 
-    def test_5_save_host_keys(self):
+    def test_save_host_keys(self):
         """
         verify that SSHClient correctly saves a known_hosts file.
         """
@@ -384,7 +384,7 @@ class SSHClientTest(ClientTest):
 
         os.unlink(localname)
 
-    def test_6_cleanup(self):
+    def test_cleanup(self):
         """
         verify that when an SSHClient is collected, its transport (and the
         transport's packetizer) is closed.
@@ -437,7 +437,7 @@ class SSHClientTest(ClientTest):
 
         self.assertTrue(self.tc._transport is None)
 
-    def test_7_banner_timeout(self):
+    def test_banner_timeout(self):
         """
         verify that the SSHClient has a configurable banner timeout.
         """
@@ -456,7 +456,7 @@ class SSHClientTest(ClientTest):
             **kwargs
         )
 
-    def test_8_auth_trickledown(self):
+    def test_auth_trickledown(self):
         """
         Failed key auth doesn't prevent subsequent pw auth from succeeding
         """
@@ -477,7 +477,7 @@ class SSHClientTest(ClientTest):
         self._test_connection(**kwargs)
 
     @slow
-    def test_9_auth_timeout(self):
+    def test_auth_timeout(self):
         """
         verify that the SSHClient has a configurable auth timeout
         """
@@ -490,7 +490,7 @@ class SSHClientTest(ClientTest):
         )
 
     @requires_gss_auth
-    def test_10_auth_trickledown_gsskex(self):
+    def test_auth_trickledown_gsskex(self):
         """
         Failed gssapi-keyex auth doesn't prevent subsequent key auth from succeeding
         """
@@ -501,7 +501,7 @@ class SSHClientTest(ClientTest):
         self._test_connection(**kwargs)
 
     @requires_gss_auth
-    def test_11_auth_trickledown_gssauth(self):
+    def test_auth_trickledown_gssauth(self):
         """
         Failed gssapi-with-mic auth doesn't prevent subsequent key auth from succeeding
         """
@@ -511,7 +511,7 @@ class SSHClientTest(ClientTest):
         )
         self._test_connection(**kwargs)
 
-    def test_12_reject_policy(self):
+    def test_reject_policy(self):
         """
         verify that SSHClient's RejectPolicy works.
         """
@@ -527,7 +527,7 @@ class SSHClientTest(ClientTest):
         )
 
     @requires_gss_auth
-    def test_13_reject_policy_gsskex(self):
+    def test_reject_policy_gsskex(self):
         """
         verify that SSHClient's RejectPolicy works,
         even if gssapi-keyex was enabled but not used.

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -51,7 +51,7 @@ class LoopbackFile (BufferedFile):
 
 class BufferedFileTest (unittest.TestCase):
 
-    def test_1_simple(self):
+    def test_simple(self):
         f = LoopbackFile('r')
         try:
             f.write(b'hi')
@@ -68,7 +68,7 @@ class BufferedFileTest (unittest.TestCase):
             pass
         f.close()
 
-    def test_2_readline(self):
+    def test_readline(self):
         f = LoopbackFile('r+U')
         f.write(b'First line.\nSecond line.\r\nThird line.\n' +
                 b'Fourth line.\nFinal line non-terminated.')
@@ -93,7 +93,7 @@ class BufferedFileTest (unittest.TestCase):
         self.assertTrue(crlf in f.newlines)
         self.assertTrue(cr_byte not in f.newlines)
 
-    def test_3_lf(self):
+    def test_lf(self):
         """
         try to trick the linefeed detector.
         """
@@ -105,7 +105,7 @@ class BufferedFileTest (unittest.TestCase):
         f.close()
         self.assertEqual(f.newlines, crlf)
 
-    def test_4_write(self):
+    def test_write(self):
         """
         verify that write buffering is on.
         """
@@ -117,7 +117,7 @@ class BufferedFileTest (unittest.TestCase):
         self.assertEqual(f.readline(), 'Incomplete line...\n')
         f.close()
 
-    def test_5_flush(self):
+    def test_flush(self):
         """
         verify that flush will force a write.
         """
@@ -131,7 +131,7 @@ class BufferedFileTest (unittest.TestCase):
         self.assertEqual(f.read(3), b'')
         f.close()
 
-    def test_6_buffering(self):
+    def test_buffering_flushes(self):
         """
         verify that flushing happens automatically on buffer crossing.
         """
@@ -144,7 +144,7 @@ class BufferedFileTest (unittest.TestCase):
         self.assertEqual(f.read(20), b'Too small.  Enough.')
         f.close()
 
-    def test_7_read_all(self):
+    def test_read_all(self):
         """
         verify that read(-1) returns everything left in the file.
         """
@@ -157,7 +157,7 @@ class BufferedFileTest (unittest.TestCase):
         f.close()
 
     @needs_builtin('buffer')
-    def test_8_buffering(self):
+    def test_buffering_writes(self):
         """
         verify that buffered objects can be written
         """
@@ -165,21 +165,21 @@ class BufferedFileTest (unittest.TestCase):
         f.write(buffer(b'Too small.'))  # noqa: F821
         f.close()
 
-    def test_9_readable(self):
+    def test_readable(self):
         f = LoopbackFile('r')
         self.assertTrue(f.readable())
         self.assertFalse(f.writable())
         self.assertFalse(f.seekable())
         f.close()
 
-    def test_A_writable(self):
+    def test_writable(self):
         f = LoopbackFile('w')
         self.assertTrue(f.writable())
         self.assertFalse(f.readable())
         self.assertFalse(f.seekable())
         f.close()
 
-    def test_B_readinto(self):
+    def test_readinto(self):
         data = bytearray(5)
         f = LoopbackFile('r+')
         f._write(b"hello")

--- a/tests/test_gssapi.py
+++ b/tests/test_gssapi.py
@@ -35,7 +35,7 @@ class GSSAPITest(KerberosTestCase):
         self.server_mode = False
         update_env(self, self.realm.env)
 
-    def test_1_pyasn1(self):
+    def test_pyasn1(self):
         """
         Test the used methods of pyasn1.
         """
@@ -185,13 +185,13 @@ class GSSAPITest(KerberosTestCase):
                 c_token = token[0].Buffer
                 self.assertNotEqual(0, error)
 
-    def test_2_gssapi_sspi_client(self):
+    def test_gssapi_sspi_client(self):
         """
         Test the used methods of python-gssapi or sspi, sspicon from pywin32.
         """
         self._gssapi_sspi_test()
 
-    def test_3_gssapi_sspi_server(self):
+    def test_gssapi_sspi_server(self):
         """
         Test the used methods of python-gssapi or sspi, sspicon from pywin32.
         """

--- a/tests/test_hostkeys.py
+++ b/tests/test_hostkeys.py
@@ -63,7 +63,7 @@ class HostKeysTest (unittest.TestCase):
     def tearDown(self):
         os.unlink('hostfile.temp')
 
-    def test_1_load(self):
+    def test_load(self):
         hostdict = paramiko.HostKeys('hostfile.temp')
         self.assertEqual(2, len(hostdict))
         self.assertEqual(1, len(list(hostdict.values())[0]))
@@ -71,7 +71,7 @@ class HostKeysTest (unittest.TestCase):
         fp = hexlify(hostdict['secure.example.com']['ssh-rsa'].get_fingerprint()).upper()
         self.assertEqual(b'E6684DB30E109B67B70FF1DC5C7F1363', fp)
 
-    def test_2_add(self):
+    def test_add(self):
         hostdict = paramiko.HostKeys('hostfile.temp')
         hh = '|1|BMsIC6cUIP2zBuXR3t2LRcJYjzM=|hpkJMysjTk/+zzUUzxQEa2ieq6c='
         key = paramiko.RSAKey(data=decodebytes(keyblob))
@@ -82,7 +82,7 @@ class HostKeysTest (unittest.TestCase):
         self.assertEqual(b'7EC91BB336CB6D810B124B1353C32396', fp)
         self.assertTrue(hostdict.check('foo.example.com', key))
 
-    def test_3_dict(self):
+    def test_dict(self):
         hostdict = paramiko.HostKeys('hostfile.temp')
         self.assertTrue('secure.example.com' in hostdict)
         self.assertTrue('not.example.com' not in hostdict)
@@ -97,7 +97,7 @@ class HostKeysTest (unittest.TestCase):
             i += 1
         self.assertEqual(2, i)
 
-    def test_4_dict_set(self):
+    def test_dict_set(self):
         hostdict = paramiko.HostKeys('hostfile.temp')
         key = paramiko.RSAKey(data=decodebytes(keyblob))
         key_dss = paramiko.DSSKey(data=decodebytes(keyblob_dss))

--- a/tests/test_kex.py
+++ b/tests/test_kex.py
@@ -145,7 +145,7 @@ class KexTest (unittest.TestCase):
         os.urandom = self._original_urandom
         KexNistp256._generate_key_pair = self._original_generate_key_pair
 
-    def test_1_group1_client(self):
+    def test_group1_client(self):
         transport = FakeTransport()
         transport.server_mode = False
         kex = KexGroup1(transport)
@@ -167,7 +167,7 @@ class KexTest (unittest.TestCase):
         self.assertEqual((b'fake-host-key', b'fake-sig'), transport._verify)
         self.assertTrue(transport._activated)
 
-    def test_2_group1_server(self):
+    def test_group1_server(self):
         transport = FakeTransport()
         transport.server_mode = True
         kex = KexGroup1(transport)
@@ -185,7 +185,7 @@ class KexTest (unittest.TestCase):
         self.assertEqual(x, hexlify(transport._message.asbytes()).upper())
         self.assertTrue(transport._activated)
 
-    def test_3_gex_client(self):
+    def test_gex_client(self):
         transport = FakeTransport()
         transport.server_mode = False
         kex = KexGex(transport)
@@ -215,7 +215,7 @@ class KexTest (unittest.TestCase):
         self.assertEqual((b'fake-host-key', b'fake-sig'), transport._verify)
         self.assertTrue(transport._activated)
 
-    def test_4_gex_old_client(self):
+    def test_gex_old_client(self):
         transport = FakeTransport()
         transport.server_mode = False
         kex = KexGex(transport)
@@ -245,7 +245,7 @@ class KexTest (unittest.TestCase):
         self.assertEqual((b'fake-host-key', b'fake-sig'), transport._verify)
         self.assertTrue(transport._activated)
 
-    def test_5_gex_server(self):
+    def test_gex_server(self):
         transport = FakeTransport()
         transport.server_mode = True
         kex = KexGex(transport)
@@ -276,7 +276,7 @@ class KexTest (unittest.TestCase):
         self.assertEqual(x, hexlify(transport._message.asbytes()).upper())
         self.assertTrue(transport._activated)
 
-    def test_6_gex_server_with_old_client(self):
+    def test_gex_server_with_old_client(self):
         transport = FakeTransport()
         transport.server_mode = True
         kex = KexGex(transport)
@@ -305,7 +305,7 @@ class KexTest (unittest.TestCase):
         self.assertEqual(x, hexlify(transport._message.asbytes()).upper())
         self.assertTrue(transport._activated)
 
-    def test_7_gex_sha256_client(self):
+    def test_gex_sha256_client(self):
         transport = FakeTransport()
         transport.server_mode = False
         kex = KexGexSHA256(transport)
@@ -335,7 +335,7 @@ class KexTest (unittest.TestCase):
         self.assertEqual((b'fake-host-key', b'fake-sig'), transport._verify)
         self.assertTrue(transport._activated)
 
-    def test_8_gex_sha256_old_client(self):
+    def test_gex_sha256_old_client(self):
         transport = FakeTransport()
         transport.server_mode = False
         kex = KexGexSHA256(transport)
@@ -365,7 +365,7 @@ class KexTest (unittest.TestCase):
         self.assertEqual((b'fake-host-key', b'fake-sig'), transport._verify)
         self.assertTrue(transport._activated)
 
-    def test_9_gex_sha256_server(self):
+    def test_gex_sha256_server(self):
         transport = FakeTransport()
         transport.server_mode = True
         kex = KexGexSHA256(transport)
@@ -396,7 +396,7 @@ class KexTest (unittest.TestCase):
         self.assertEqual(x, hexlify(transport._message.asbytes()).upper())
         self.assertTrue(transport._activated)
 
-    def test_10_gex_sha256_server_with_old_client(self):
+    def test_gex_sha256_server_with_old_client(self):
         transport = FakeTransport()
         transport.server_mode = True
         kex = KexGexSHA256(transport)
@@ -425,7 +425,7 @@ class KexTest (unittest.TestCase):
         self.assertEqual(x, hexlify(transport._message.asbytes()).upper())
         self.assertTrue(transport._activated)
 
-    def test_11_kex_nistp256_client(self):
+    def test_kex_nistp256_client(self):
         K = 91610929826364598472338906427792435253694642563583721654249504912114314269754
         transport = FakeTransport()
         transport.server_mode = False
@@ -447,7 +447,7 @@ class KexTest (unittest.TestCase):
         self.assertEqual((b'fake-host-key', b'fake-sig'), transport._verify)
         self.assertTrue(transport._activated)
 
-    def test_12_kex_nistp256_server(self):
+    def test_kex_nistp256_server(self):
         K = 91610929826364598472338906427792435253694642563583721654249504912114314269754
         transport = FakeTransport()
         transport.server_mode = True
@@ -466,7 +466,7 @@ class KexTest (unittest.TestCase):
         self.assertTrue(transport._activated)
         self.assertEqual(H, hexlify(transport._H).upper())
 
-    def test_13_kex_group14_sha256_client(self):
+    def test_kex_group14_sha256_client(self):
         transport = FakeTransport()
         transport.server_mode = False
         kex = KexGroup14SHA256(transport)
@@ -489,7 +489,7 @@ class KexTest (unittest.TestCase):
         self.assertEqual((b'fake-host-key', b'fake-sig'), transport._verify)
         self.assertTrue(transport._activated)
 
-    def test_14_kex_group16_sha512_client(self):
+    def test_kex_group16_sha512_client(self):
         transport = FakeTransport()
         transport.server_mode = False
         kex = KexGroup16SHA512(transport)
@@ -513,7 +513,7 @@ class KexTest (unittest.TestCase):
         self.assertTrue(transport._activated)
 
     @pytest.mark.skipif("not KexCurve25519.is_supported()")
-    def test_15_kex_c25519_client(self):
+    def test_kex_c25519_client(self):
         K = 71294722834835117201316639182051104803802881348227506835068888449366462300724
         transport = FakeTransport()
         transport.server_mode = False
@@ -540,7 +540,7 @@ class KexTest (unittest.TestCase):
         self.assertTrue(transport._activated)
 
     @pytest.mark.skipif("not KexCurve25519.is_supported()")
-    def test_16_kex_c25519_server(self):
+    def test_kex_c25519_server(self):
         K = 71294722834835117201316639182051104803802881348227506835068888449366462300724
         transport = FakeTransport()
         transport.server_mode = True

--- a/tests/test_kex_gss.py
+++ b/tests/test_kex_gss.py
@@ -130,7 +130,7 @@ class GSSKexTest(KerberosTestCase):
         stdout.close()
         stderr.close()
 
-    def test_1_gsskex_and_auth(self):
+    def test_gsskex_and_auth(self):
         """
         Verify that Paramiko can handle SSHv2 GSS-API / SSPI authenticated
         Diffie-Hellman Key Exchange and user authentication with the GSS-API
@@ -139,7 +139,7 @@ class GSSKexTest(KerberosTestCase):
         self._test_gsskex_and_auth(gss_host=None)
 
     @unittest.expectedFailure  # https://github.com/paramiko/paramiko/issues/1312
-    def test_2_gsskex_and_auth_rekey(self):
+    def test_gsskex_and_auth_rekey(self):
         """
         Verify that Paramiko can rekey.
         """

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -33,7 +33,7 @@ class MessageTest (unittest.TestCase):
     __c = b'\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\xf5\xe4\xd3\xc2\xb1\x09\x00\x00\x00\x01\x11\x00\x00\x00\x07\x00\xf5\xe4\xd3\xc2\xb1\x09\x00\x00\x00\x06\x9a\x1b\x2c\x3d\x4e\xf7'  # noqa: E501
     __d = b'\x00\x00\x00\x05\x01\x00\x00\x00\x03\x63\x61\x74\x00\x00\x00\x03\x61\x2c\x62'
 
-    def test_1_encode(self):
+    def test_encode(self):
         msg = Message()
         msg.add_int(23)
         msg.add_int(123789456)
@@ -59,7 +59,7 @@ class MessageTest (unittest.TestCase):
         msg.add_mpint(-0x65e4d3c2b109)
         self.assertEqual(msg.asbytes(), self.__c)
 
-    def test_2_decode(self):
+    def test_decode(self):
         msg = Message(self.__a)
         self.assertEqual(msg.get_int(), 23)
         self.assertEqual(msg.get_int(), 123789456)
@@ -81,7 +81,7 @@ class MessageTest (unittest.TestCase):
         self.assertEqual(msg.get_mpint(), 0xf5e4d3c2b109)
         self.assertEqual(msg.get_mpint(), -0x65e4d3c2b109)
 
-    def test_3_add(self):
+    def test_add(self):
         msg = Message()
         msg.add(5)
         msg.add(True)
@@ -89,7 +89,7 @@ class MessageTest (unittest.TestCase):
         msg.add(['a', 'b'])
         self.assertEqual(msg.asbytes(), self.__d)
 
-    def test_4_misc(self):
+    def test_misc(self):
         msg = Message(self.__d)
         self.assertEqual(msg.get_int(), 5)
         self.assertEqual(msg.get_boolean(), True)

--- a/tests/test_packetizer.py
+++ b/tests/test_packetizer.py
@@ -24,6 +24,8 @@ import sys
 import unittest
 from hashlib import sha1
 
+import pytest
+
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
 
@@ -88,9 +90,8 @@ class PacketizerTest (unittest.TestCase):
         self.assertEqual(1, m.get_int())
         self.assertEqual(900, m.get_int())
 
+    @pytest.mark.skipif(sys.platform.startswith('win'), reason="no SIGALRM on windows")
     def test_closed(self):
-        if sys.platform.startswith("win"): # no SIGALRM on windows
-            return
         rsock = LoopSocket()
         wsock = LoopSocket()
         rsock.link(wsock)

--- a/tests/test_packetizer.py
+++ b/tests/test_packetizer.py
@@ -39,7 +39,7 @@ x1f = byte_chr(0x1f)
 
 class PacketizerTest (unittest.TestCase):
 
-    def test_1_write(self):
+    def test_write(self):
         rsock = LoopSocket()
         wsock = LoopSocket()
         rsock.link(wsock)
@@ -68,7 +68,7 @@ class PacketizerTest (unittest.TestCase):
             b'\x43\x91\x97\xbd\x5b\x50\xac\x25\x87\xc2\xc4\x6b\xc7\xe9\x38\xc0', data[:16]
         )
 
-    def test_2_read(self):
+    def test_read(self):
         rsock = LoopSocket()
         wsock = LoopSocket()
         rsock.link(wsock)
@@ -88,7 +88,7 @@ class PacketizerTest (unittest.TestCase):
         self.assertEqual(1, m.get_int())
         self.assertEqual(900, m.get_int())
 
-    def test_3_closed(self):
+    def test_closed(self):
         if sys.platform.startswith("win"): # no SIGALRM on windows
             return
         rsock = LoopSocket()

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -140,12 +140,12 @@ class KeyTest(unittest.TestCase):
             self.assertEqual(fh.readline()[:-1], "Proc-Type: 4,ENCRYPTED")
             self.assertEqual(fh.readline()[0:10], "DEK-Info: ")
 
-    def test_1_generate_key_bytes(self):
+    def test_generate_key_bytes(self):
         key = util.generate_key_bytes(md5, x1234, 'happy birthday', 30)
         exp = b'\x61\xE1\xF2\x72\xF4\xC1\xC4\x56\x15\x86\xBD\x32\x24\x98\xC0\xE9\x24\x67\x27\x80\xF4\x7B\xB3\x7D\xDA\x7D\x54\x01\x9E\x64'  # noqa: E501
         self.assertEqual(exp, key)
 
-    def test_2_load_rsa(self):
+    def test_load_rsa(self):
         key = RSAKey.from_private_key_file(_support('test_rsa.key'))
         self.assertEqual('ssh-rsa', key.get_name())
         exp_rsa = b(FINGER_RSA.split()[1].replace(':', ''))
@@ -161,7 +161,7 @@ class KeyTest(unittest.TestCase):
         key2 = RSAKey.from_private_key(s)
         self.assertEqual(key, key2)
 
-    def test_3_load_rsa_password(self):
+    def test_load_rsa_password(self):
         key = RSAKey.from_private_key_file(_support('test_rsa_password.key'), 'television')
         self.assertEqual('ssh-rsa', key.get_name())
         exp_rsa = b(FINGER_RSA.split()[1].replace(':', ''))
@@ -170,7 +170,7 @@ class KeyTest(unittest.TestCase):
         self.assertEqual(PUB_RSA.split()[1], key.get_base64())
         self.assertEqual(1024, key.get_bits())
 
-    def test_4_load_dss(self):
+    def test_load_dss(self):
         key = DSSKey.from_private_key_file(_support('test_dss.key'))
         self.assertEqual('ssh-dss', key.get_name())
         exp_dss = b(FINGER_DSS.split()[1].replace(':', ''))
@@ -186,7 +186,7 @@ class KeyTest(unittest.TestCase):
         key2 = DSSKey.from_private_key(s)
         self.assertEqual(key, key2)
 
-    def test_5_load_dss_password(self):
+    def test_load_dss_password(self):
         key = DSSKey.from_private_key_file(_support('test_dss_password.key'), 'television')
         self.assertEqual('ssh-dss', key.get_name())
         exp_dss = b(FINGER_DSS.split()[1].replace(':', ''))
@@ -195,7 +195,7 @@ class KeyTest(unittest.TestCase):
         self.assertEqual(PUB_DSS.split()[1], key.get_base64())
         self.assertEqual(1024, key.get_bits())
 
-    def test_6_compare_rsa(self):
+    def test_compare_rsa(self):
         # verify that the private & public keys compare equal
         key = RSAKey.from_private_key_file(_support('test_rsa.key'))
         self.assertEqual(key, key)
@@ -204,7 +204,7 @@ class KeyTest(unittest.TestCase):
         self.assertTrue(not pub.can_sign())
         self.assertEqual(key, pub)
 
-    def test_7_compare_dss(self):
+    def test_compare_dss(self):
         # verify that the private & public keys compare equal
         key = DSSKey.from_private_key_file(_support('test_dss.key'))
         self.assertEqual(key, key)
@@ -213,7 +213,7 @@ class KeyTest(unittest.TestCase):
         self.assertTrue(not pub.can_sign())
         self.assertEqual(key, pub)
 
-    def test_8_sign_rsa(self):
+    def test_sign_rsa(self):
         # verify that the rsa private key can sign and verify
         key = RSAKey.from_private_key_file(_support('test_rsa.key'))
         msg = key.sign_ssh_data(b'ice weasels')
@@ -226,7 +226,7 @@ class KeyTest(unittest.TestCase):
         pub = RSAKey(data=key.asbytes())
         self.assertTrue(pub.verify_ssh_sig(b'ice weasels', msg))
 
-    def test_9_sign_dss(self):
+    def test_sign_dss(self):
         # verify that the dss private key can sign and verify
         key = DSSKey.from_private_key_file(_support('test_dss.key'))
         msg = key.sign_ssh_data(b'ice weasels')
@@ -241,19 +241,19 @@ class KeyTest(unittest.TestCase):
         pub = DSSKey(data=key.asbytes())
         self.assertTrue(pub.verify_ssh_sig(b'ice weasels', msg))
 
-    def test_A_generate_rsa(self):
+    def test_generate_rsa(self):
         key = RSAKey.generate(1024)
         msg = key.sign_ssh_data(b'jerri blank')
         msg.rewind()
         self.assertTrue(key.verify_ssh_sig(b'jerri blank', msg))
 
-    def test_B_generate_dss(self):
+    def test_generate_dss(self):
         key = DSSKey.generate(1024)
         msg = key.sign_ssh_data(b'jerri blank')
         msg.rewind()
         self.assertTrue(key.verify_ssh_sig(b'jerri blank', msg))
 
-    def test_C_generate_ecdsa(self):
+    def test_generate_ecdsa(self):
         key = ECDSAKey.generate()
         msg = key.sign_ssh_data(b'jerri blank')
         msg.rewind()
@@ -282,7 +282,7 @@ class KeyTest(unittest.TestCase):
         self.assertEqual(key.get_bits(), 521)
         self.assertEqual(key.get_name(), 'ecdsa-sha2-nistp521')
 
-    def test_10_load_ecdsa_256(self):
+    def test_load_ecdsa_256(self):
         key = ECDSAKey.from_private_key_file(_support('test_ecdsa_256.key'))
         self.assertEqual('ecdsa-sha2-nistp256', key.get_name())
         exp_ecdsa = b(FINGER_ECDSA_256.split()[1].replace(':', ''))
@@ -298,7 +298,7 @@ class KeyTest(unittest.TestCase):
         key2 = ECDSAKey.from_private_key(s)
         self.assertEqual(key, key2)
 
-    def test_11_load_ecdsa_password_256(self):
+    def test_load_ecdsa_password_256(self):
         key = ECDSAKey.from_private_key_file(_support('test_ecdsa_password_256.key'),
                                              b'television')
         self.assertEqual('ecdsa-sha2-nistp256', key.get_name())
@@ -308,7 +308,7 @@ class KeyTest(unittest.TestCase):
         self.assertEqual(PUB_ECDSA_256.split()[1], key.get_base64())
         self.assertEqual(256, key.get_bits())
 
-    def test_12_compare_ecdsa_256(self):
+    def test_compare_ecdsa_256(self):
         # verify that the private & public keys compare equal
         key = ECDSAKey.from_private_key_file(_support('test_ecdsa_256.key'))
         self.assertEqual(key, key)
@@ -317,7 +317,7 @@ class KeyTest(unittest.TestCase):
         self.assertTrue(not pub.can_sign())
         self.assertEqual(key, pub)
 
-    def test_13_sign_ecdsa_256(self):
+    def test_sign_ecdsa_256(self):
         # verify that the rsa private key can sign and verify
         key = ECDSAKey.from_private_key_file(_support('test_ecdsa_256.key'))
         msg = key.sign_ssh_data(b'ice weasels')
@@ -333,7 +333,7 @@ class KeyTest(unittest.TestCase):
         pub = ECDSAKey(data=key.asbytes())
         self.assertTrue(pub.verify_ssh_sig(b'ice weasels', msg))
 
-    def test_14_load_ecdsa_384(self):
+    def test_load_ecdsa_384(self):
         key = ECDSAKey.from_private_key_file(_support('test_ecdsa_384.key'))
         self.assertEqual('ecdsa-sha2-nistp384', key.get_name())
         exp_ecdsa = b(FINGER_ECDSA_384.split()[1].replace(':', ''))
@@ -349,7 +349,7 @@ class KeyTest(unittest.TestCase):
         key2 = ECDSAKey.from_private_key(s)
         self.assertEqual(key, key2)
 
-    def test_15_load_ecdsa_password_384(self):
+    def test_load_ecdsa_password_384(self):
         key = ECDSAKey.from_private_key_file(_support('test_ecdsa_password_384.key'),
                                              b'television')
         self.assertEqual('ecdsa-sha2-nistp384', key.get_name())
@@ -359,7 +359,7 @@ class KeyTest(unittest.TestCase):
         self.assertEqual(PUB_ECDSA_384.split()[1], key.get_base64())
         self.assertEqual(384, key.get_bits())
 
-    def test_16_compare_ecdsa_384(self):
+    def test_compare_ecdsa_384(self):
         # verify that the private & public keys compare equal
         key = ECDSAKey.from_private_key_file(_support('test_ecdsa_384.key'))
         self.assertEqual(key, key)
@@ -368,7 +368,7 @@ class KeyTest(unittest.TestCase):
         self.assertTrue(not pub.can_sign())
         self.assertEqual(key, pub)
 
-    def test_17_sign_ecdsa_384(self):
+    def test_sign_ecdsa_384(self):
         # verify that the rsa private key can sign and verify
         key = ECDSAKey.from_private_key_file(_support('test_ecdsa_384.key'))
         msg = key.sign_ssh_data(b'ice weasels')
@@ -384,7 +384,7 @@ class KeyTest(unittest.TestCase):
         pub = ECDSAKey(data=key.asbytes())
         self.assertTrue(pub.verify_ssh_sig(b'ice weasels', msg))
 
-    def test_18_load_ecdsa_521(self):
+    def test_load_ecdsa_521(self):
         key = ECDSAKey.from_private_key_file(_support('test_ecdsa_521.key'))
         self.assertEqual('ecdsa-sha2-nistp521', key.get_name())
         exp_ecdsa = b(FINGER_ECDSA_521.split()[1].replace(':', ''))
@@ -403,7 +403,7 @@ class KeyTest(unittest.TestCase):
         key2 = ECDSAKey.from_private_key(s)
         self.assertEqual(key, key2)
 
-    def test_19_load_ecdsa_password_521(self):
+    def test_load_ecdsa_password_521(self):
         key = ECDSAKey.from_private_key_file(_support('test_ecdsa_password_521.key'),
                                              b'television')
         self.assertEqual('ecdsa-sha2-nistp521', key.get_name())
@@ -413,7 +413,7 @@ class KeyTest(unittest.TestCase):
         self.assertEqual(PUB_ECDSA_521.split()[1], key.get_base64())
         self.assertEqual(521, key.get_bits())
 
-    def test_20_compare_ecdsa_521(self):
+    def test_compare_ecdsa_521(self):
         # verify that the private & public keys compare equal
         key = ECDSAKey.from_private_key_file(_support('test_ecdsa_521.key'))
         self.assertEqual(key, key)
@@ -422,7 +422,7 @@ class KeyTest(unittest.TestCase):
         self.assertTrue(not pub.can_sign())
         self.assertEqual(key, pub)
 
-    def test_21_sign_ecdsa_521(self):
+    def test_sign_ecdsa_521(self):
         # verify that the rsa private key can sign and verify
         key = ECDSAKey.from_private_key_file(_support('test_ecdsa_521.key'))
         msg = key.sign_ssh_data(b'ice weasels')
@@ -438,7 +438,7 @@ class KeyTest(unittest.TestCase):
         pub = ECDSAKey(data=key.asbytes())
         self.assertTrue(pub.verify_ssh_sig(b'ice weasels', msg))
 
-    def test_22_load_RSA_key_new_format(self):
+    def test_load_RSA_key_new_format(self):
         key = RSAKey.from_private_key_file(_support('test_rsa_2k_o.key'), b'television')
         self.assertEqual('ssh-rsa', key.get_name())
         self.assertEqual(PUB_RSA_2K_OPENSSH.split()[1], key.get_base64())
@@ -447,7 +447,7 @@ class KeyTest(unittest.TestCase):
         my_rsa = hexlify(key.get_fingerprint())
         self.assertEqual(exp_rsa, my_rsa)
 
-    def test_23_load_DSS_key_new_format(self):
+    def test_load_DSS_key_new_format(self):
         key = DSSKey.from_private_key_file(_support('test_dss_1k_o.key'), b'television')
         self.assertEqual('ssh-dss', key.get_name())
         self.assertEqual(PUB_DSS_1K_OPENSSH.split()[1], key.get_base64())
@@ -456,7 +456,7 @@ class KeyTest(unittest.TestCase):
         my_rsa = hexlify(key.get_fingerprint())
         self.assertEqual(exp_rsa, my_rsa)
 
-    def test_24_load_EC_key_new_format(self):
+    def test_load_EC_key_new_format(self):
         key = ECDSAKey.from_private_key_file(_support('test_ecdsa_384_o.key'), b'television')
         self.assertEqual('ecdsa-sha2-nistp384', key.get_name())
         self.assertEqual(PUB_EC_384_OPENSSH.split()[1], key.get_base64())

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -385,14 +385,11 @@ class TestSFTP(object):
         finally:
             sftp.remove(sftp.FOLDER + '/testing.txt')
 
+    @pytest.mark.skipif("not hasattr(os, 'symlink')")  # on windows
     def test_symlink(self, sftp):
         """
         create a symlink and then check that lstat doesn't follow it.
         """
-        if not hasattr(os, "symlink"):
-            # skip symlink tests on windows
-            return
-
         try:
             with sftp.open(sftp.FOLDER + '/original.txt', 'w') as f:
                 f.write('original\n')

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -85,7 +85,7 @@ utf8_folder = b'/\xc3\xbcnic\xc3\xb8\x64\x65'
 
 @slow
 class TestSFTP(object):
-    def test_1_file(self, sftp):
+    def test_file(self, sftp):
         """
         verify that we can create a file.
         """
@@ -96,7 +96,7 @@ class TestSFTP(object):
             f.close()
             sftp.remove(sftp.FOLDER + '/test')
 
-    def test_2_close(self, sftp):
+    def test_close(self, sftp):
         """
         Verify that SFTP session close() causes a socket error on next action.
         """
@@ -104,7 +104,7 @@ class TestSFTP(object):
         with pytest.raises(socket.error, match='Socket is closed'):
             sftp.open(sftp.FOLDER + '/test2', 'w')
 
-    def test_2_sftp_can_be_used_as_context_manager(self, sftp):
+    def test_sftp_can_be_used_as_context_manager(self, sftp):
         """
         verify that the sftp session is closed when exiting the context manager
         """
@@ -113,7 +113,7 @@ class TestSFTP(object):
         with pytest.raises(socket.error, match='Socket is closed'):
             sftp.open(sftp.FOLDER + '/test2', 'w')
 
-    def test_3_write(self, sftp):
+    def test_write(self, sftp):
         """
         verify that a file can be created and written, and the size is correct.
         """
@@ -124,7 +124,7 @@ class TestSFTP(object):
         finally:
             sftp.remove(sftp.FOLDER + '/duck.txt')
 
-    def test_3_sftp_file_can_be_used_as_context_manager(self, sftp):
+    def test_sftp_file_can_be_used_as_context_manager(self, sftp):
         """
         verify that an opened file can be used as a context manager
         """
@@ -135,7 +135,7 @@ class TestSFTP(object):
         finally:
             sftp.remove(sftp.FOLDER + '/duck.txt')
 
-    def test_4_append(self, sftp):
+    def test_append(self, sftp):
         """
         verify that a file can be opened for append, and tell() still works.
         """
@@ -153,7 +153,7 @@ class TestSFTP(object):
         finally:
             sftp.remove(sftp.FOLDER + '/append.txt')
 
-    def test_5_rename(self, sftp):
+    def test_rename(self, sftp):
         """
         verify that renaming a file works.
         """
@@ -178,7 +178,7 @@ class TestSFTP(object):
             except:
                 pass
 
-    def test_5a_posix_rename(self, sftp):
+    def test_posix_rename(self, sftp):
         """Test posix-rename@openssh.com protocol extension."""
         try:
             # first check that the normal rename works as specified
@@ -207,7 +207,7 @@ class TestSFTP(object):
             except:
                 pass
 
-    def test_6_folder(self, sftp):
+    def test_folder(self, sftp):
         """
         create a temporary folder, verify that we can create a file in it, then
         remove the folder and verify that we can't create a file in it anymore.
@@ -220,7 +220,7 @@ class TestSFTP(object):
         with pytest.raises(IOError, match="No such file"):
             sftp.open(sftp.FOLDER + '/subfolder/test')
 
-    def test_7_listdir(self, sftp):
+    def test_listdir(self, sftp):
         """
         verify that a folder can be created, a bunch of files can be placed in
         it, and those files show up in sftp.listdir.
@@ -241,7 +241,7 @@ class TestSFTP(object):
             sftp.remove(sftp.FOLDER + '/fish.txt')
             sftp.remove(sftp.FOLDER + '/tertiary.py')
 
-    def test_7_5_listdir_iter(self, sftp):
+    def test_listdir_iter(self, sftp):
         """
         listdir_iter version of above test
         """
@@ -261,7 +261,7 @@ class TestSFTP(object):
             sftp.remove(sftp.FOLDER + '/fish.txt')
             sftp.remove(sftp.FOLDER + '/tertiary.py')
 
-    def test_8_setstat(self, sftp):
+    def test_setstat(self, sftp):
         """
         verify that the setstat functions (chown, chmod, utime, truncate) work.
         """
@@ -298,7 +298,7 @@ class TestSFTP(object):
         finally:
             sftp.remove(sftp.FOLDER + '/special')
 
-    def test_9_fsetstat(self, sftp):
+    def test_fsetstat(self, sftp):
         """
         verify that the fsetstat functions (chown, chmod, utime, truncate)
         work on open files.
@@ -338,7 +338,7 @@ class TestSFTP(object):
         finally:
             sftp.remove(sftp.FOLDER + '/special')
 
-    def test_A_readline_seek(self, sftp):
+    def test_readline_seek(self, sftp):
         """
         create a text file and write a bunch of text into it.  then count the lines
         in the file, and seek around to retrieve particular lines.  this should
@@ -367,7 +367,7 @@ class TestSFTP(object):
         finally:
             sftp.remove(sftp.FOLDER + '/duck.txt')
 
-    def test_B_write_seek(self, sftp):
+    def test_write_seek(self, sftp):
         """
         create a text file, seek back and change part of it, and verify that the
         changes worked.
@@ -385,7 +385,7 @@ class TestSFTP(object):
         finally:
             sftp.remove(sftp.FOLDER + '/testing.txt')
 
-    def test_C_symlink(self, sftp):
+    def test_symlink(self, sftp):
         """
         create a symlink and then check that lstat doesn't follow it.
         """
@@ -430,7 +430,7 @@ class TestSFTP(object):
             except:
                 pass
 
-    def test_D_flush_seek(self, sftp):
+    def test_flush_seek(self, sftp):
         """
         verify that buffered writes are automatically flushed on seek.
         """
@@ -450,7 +450,7 @@ class TestSFTP(object):
             except:
                 pass
 
-    def test_E_realpath(self, sftp):
+    def test_realpath(self, sftp):
         """
         test that realpath is returning something non-empty and not an
         error.
@@ -461,7 +461,7 @@ class TestSFTP(object):
         assert len(f) > 0
         assert os.path.join(pwd, sftp.FOLDER) == f
 
-    def test_F_mkdir(self, sftp):
+    def test_mkdir(self, sftp):
         """
         verify that mkdir/rmdir work.
         """
@@ -472,7 +472,7 @@ class TestSFTP(object):
         with pytest.raises(IOError, match="No such file"):
             sftp.rmdir(sftp.FOLDER + '/subfolder')
 
-    def test_G_chdir(self, sftp):
+    def test_chdir(self, sftp):
         """
         verify that chdir/getcwd work.
         """
@@ -508,7 +508,7 @@ class TestSFTP(object):
             except:
                 pass
 
-    def test_H_get_put(self, sftp):
+    def test_get_put(self, sftp):
         """
         verify that get/put work.
         """
@@ -542,7 +542,7 @@ class TestSFTP(object):
         os.unlink(localname)
         sftp.unlink(sftp.FOLDER + '/bunny.txt')
 
-    def test_I_check(self, sftp):
+    def test_check(self, sftp):
         """
         verify that file.check() works against our own server.
         (it's an sftp extension that we support, and may be the only ones who
@@ -562,7 +562,7 @@ class TestSFTP(object):
         finally:
             sftp.unlink(sftp.FOLDER + '/kitty.txt')
 
-    def test_J_x_flag(self, sftp):
+    def test_x_flag(self, sftp):
         """
         verify that the 'x' flag works when opening a file.
         """
@@ -577,7 +577,7 @@ class TestSFTP(object):
         finally:
             sftp.unlink(sftp.FOLDER + '/unusual.txt')
 
-    def test_K_utf8(self, sftp):
+    def test_utf8(self, sftp):
         """
         verify that unicode strings are encoded into utf8 correctly.
         """
@@ -591,7 +591,7 @@ class TestSFTP(object):
             self.fail('exception ' + str(e))
         sftp.unlink(b(sftp.FOLDER) + utf8_folder)
 
-    def test_L_utf8_chdir(self, sftp):
+    def test_utf8_chdir(self, sftp):
         sftp.mkdir(sftp.FOLDER + '/' + unicode_folder)
         try:
             sftp.chdir(sftp.FOLDER + '/' + unicode_folder)
@@ -602,7 +602,7 @@ class TestSFTP(object):
             sftp.chdir()
             sftp.rmdir(sftp.FOLDER + '/' + unicode_folder)
 
-    def test_M_bad_readv(self, sftp):
+    def test_bad_readv(self, sftp):
         """
         verify that readv at the end of the file doesn't essplode.
         """
@@ -618,7 +618,7 @@ class TestSFTP(object):
         finally:
             sftp.unlink(sftp.FOLDER + '/zero')
 
-    def test_N_put_without_confirm(self, sftp):
+    def test_put_without_confirm(self, sftp):
         """
         verify that get/put work without confirmation.
         """
@@ -644,7 +644,7 @@ class TestSFTP(object):
         os.unlink(localname)
         sftp.unlink(sftp.FOLDER + '/bunny.txt')
 
-    def test_O_getcwd(self, sftp):
+    def test_getcwd(self, sftp):
         """
         verify that chdir/getcwd work.
         """
@@ -663,7 +663,7 @@ class TestSFTP(object):
             except:
                 pass
 
-    def XXX_test_M_seek_append(self, sftp):
+    def test_seek_append(self, sftp):
         """
         verify that seek does't affect writes during append.
 
@@ -701,7 +701,7 @@ class TestSFTP(object):
     # appear but they're clearly emitted from subthreads that have no error
     # handling. No point running it until that is fixed somehow.
     @pytest.mark.skip("Doesn't prove anything right now")
-    def test_N_file_with_percent(self, sftp):
+    def test_file_with_percent(self, sftp):
         """
         verify that we can create a file with a '%' in the filename.
         ( it needs to be properly escaped by _log() )
@@ -713,7 +713,7 @@ class TestSFTP(object):
             f.close()
             sftp.remove(sftp.FOLDER + '/test%file')
 
-    def test_O_non_utf8_data(self, sftp):
+    def test_non_utf8_data(self, sftp):
         """Test write() and read() of non utf8 data"""
         try:
             with sftp.open('%s/nonutf8data' % sftp.FOLDER, 'w') as f:

--- a/tests/test_sftp_big.py
+++ b/tests/test_sftp_big.py
@@ -35,7 +35,7 @@ from .util import slow
 
 @slow
 class TestBigSFTP(object):
-    def test_1_lots_of_files(self, sftp):
+    def test_lots_of_files(self, sftp):
         """
         create a bunch of files over the same session.
         """
@@ -61,7 +61,7 @@ class TestBigSFTP(object):
                 except:
                     pass
 
-    def test_2_big_file(self, sftp):
+    def test_big_file(self, sftp):
         """
         write a 1MB file with no buffering.
         """
@@ -90,7 +90,7 @@ class TestBigSFTP(object):
         finally:
             sftp.remove('%s/hongry.txt' % sftp.FOLDER)
 
-    def test_3_big_file_pipelined(self, sftp):
+    def test_big_file_pipelined(self, sftp):
         """
         write a 1MB file, with no linefeeds, using pipelining.
         """
@@ -132,7 +132,7 @@ class TestBigSFTP(object):
         finally:
             sftp.remove('%s/hongry.txt' % sftp.FOLDER)
 
-    def test_4_prefetch_seek(self, sftp):
+    def test_prefetch_seek(self, sftp):
         kblob = bytes().join([struct.pack('>H', n) for n in range(512)])
         try:
             with sftp.open('%s/hongry.txt' % sftp.FOLDER, 'wb') as f:
@@ -168,7 +168,7 @@ class TestBigSFTP(object):
         finally:
             sftp.remove('%s/hongry.txt' % sftp.FOLDER)
 
-    def test_5_readv_seek(self, sftp):
+    def test_readv_seek(self, sftp):
         kblob = bytes().join([struct.pack('>H', n) for n in range(512)])
         try:
             with sftp.open('%s/hongry.txt' % sftp.FOLDER, 'wb') as f:
@@ -204,7 +204,7 @@ class TestBigSFTP(object):
         finally:
             sftp.remove('%s/hongry.txt' % sftp.FOLDER)
 
-    def test_6_lots_of_prefetching(self, sftp):
+    def test_lots_of_prefetching(self, sftp):
         """
         prefetch a 1MB file a bunch of times, discarding the file object
         without using it, to verify that paramiko doesn't get confused.
@@ -237,7 +237,7 @@ class TestBigSFTP(object):
         finally:
             sftp.remove('%s/hongry.txt' % sftp.FOLDER)
 
-    def test_7_prefetch_readv(self, sftp):
+    def test_prefetch_readv(self, sftp):
         """
         verify that prefetch and readv don't conflict with each other.
         """
@@ -273,7 +273,7 @@ class TestBigSFTP(object):
         finally:
             sftp.remove('%s/hongry.txt' % sftp.FOLDER)
 
-    def test_8_large_readv(self, sftp):
+    def test_large_readv(self, sftp):
         """
         verify that a very large readv is broken up correctly and still
         returned as a single blob.
@@ -300,7 +300,7 @@ class TestBigSFTP(object):
         finally:
             sftp.remove('%s/hongry.txt' % sftp.FOLDER)
 
-    def test_9_big_file_big_buffer(self, sftp):
+    def test_big_file_big_buffer(self, sftp):
         """
         write a 1MB file, with no linefeeds, and a big buffer.
         """
@@ -313,7 +313,7 @@ class TestBigSFTP(object):
         finally:
             sftp.remove('%s/hongry.txt' % sftp.FOLDER)
 
-    def test_A_big_file_renegotiate(self, sftp):
+    def test_big_file_renegotiate(self, sftp):
         """
         write a 1MB file, forcing key renegotiation in the middle.
         """

--- a/tests/test_ssh_gss.py
+++ b/tests/test_ssh_gss.py
@@ -134,7 +134,7 @@ class GSSAuthTest(KerberosTestCase):
         stdout.close()
         stderr.close()
 
-    def test_1_gss_auth(self):
+    def test_gss_auth(self):
         """
         Verify that Paramiko can handle SSHv2 GSS-API / SSPI authentication
         (gssapi-with-mic) in client and server mode.
@@ -142,7 +142,7 @@ class GSSAuthTest(KerberosTestCase):
         self._test_connection(allow_agent=False,
                               look_for_keys=False)
 
-    def test_2_auth_trickledown(self):
+    def test_auth_trickledown(self):
         """
         Failed gssapi-with-mic auth doesn't prevent subsequent key auth from
         succeeding

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -166,7 +166,7 @@ class TransportTest(unittest.TestCase):
         self.assertTrue(event.is_set())
         self.assertTrue(self.ts.is_active())
 
-    def test_1_security_options(self):
+    def test_security_options(self):
         o = self.tc.get_security_options()
         self.assertEqual(type(o), SecurityOptions)
         self.assertTrue(('aes256-cbc', 'blowfish-cbc') != o.ciphers)
@@ -183,7 +183,7 @@ class TransportTest(unittest.TestCase):
         except TypeError:
             pass
 
-    def test_1b_security_options_reset(self):
+    def test_security_options_reset(self):
         o = self.tc.get_security_options()
         # should not throw any exceptions
         o.ciphers = o.ciphers
@@ -192,7 +192,7 @@ class TransportTest(unittest.TestCase):
         o.kex = o.kex
         o.compression = o.compression
 
-    def test_2_compute_key(self):
+    def test_compute_key(self):
         self.tc.K = 123281095979686581523377256114209720774539068973101330872763622971399429481072519713536292772709507296759612401802191955568143056534122385270077606457721553469730659233569339356140085284052436697480759510519672848743794433460113118986816826624865291116513647975790797391795651716378444844877749505443714557929  # noqa: E501
         self.tc.H = b'\x0C\x83\x07\xCD\xE6\x85\x6F\xF3\x0B\xA9\x36\x84\xEB\x0F\x04\xC2\x52\x0E\x9E\xD3'  # noqa: E501
         self.tc.session_id = self.tc.H
@@ -200,7 +200,7 @@ class TransportTest(unittest.TestCase):
         self.assertEqual(b'207E66594CA87C44ECCBA3B3CD39FDDB378E6FDB0F97C54B2AA0CFBF900CD995',
                          hexlify(key).upper())
 
-    def test_3_simple(self):
+    def test_simple(self):
         """
         verify that we can establish an ssh link with ourselves across the
         loopback sockets.  this is hardly "simple" but it's simpler than the
@@ -227,7 +227,7 @@ class TransportTest(unittest.TestCase):
         self.assertEqual(True, self.tc.is_authenticated())
         self.assertEqual(True, self.ts.is_authenticated())
 
-    def test_3a_long_banner(self):
+    def test_long_banner(self):
         """
         verify that a long banner doesn't mess up the handshake.
         """
@@ -245,7 +245,7 @@ class TransportTest(unittest.TestCase):
         self.assertTrue(event.is_set())
         self.assertTrue(self.ts.is_active())
 
-    def test_4_special(self):
+    def test_special(self):
         """
         verify that the client can demand odd handshake settings, and can
         renegotiate keys in mid-stream.
@@ -264,7 +264,7 @@ class TransportTest(unittest.TestCase):
         self.ts.send_ignore(1024)
 
     @slow
-    def test_5_keepalive(self):
+    def test_keepalive(self):
         """
         verify that the keepalive will be sent.
         """
@@ -274,7 +274,7 @@ class TransportTest(unittest.TestCase):
         time.sleep(2)
         self.assertEqual('keepalive@lag.net', self.server._global_request)
 
-    def test_6_exec_command(self):
+    def test_exec_command(self):
         """
         verify that exec_command() does something reasonable.
         """
@@ -316,7 +316,7 @@ class TransportTest(unittest.TestCase):
         self.assertEqual('This is on stderr.\n', f.readline())
         self.assertEqual('', f.readline())
 
-    def test_6a_channel_can_be_used_as_context_manager(self):
+    def test_channel_can_be_used_as_context_manager(self):
         """
         verify that exec_command() does something reasonable.
         """
@@ -332,7 +332,7 @@ class TransportTest(unittest.TestCase):
                 self.assertEqual('Hello there.\n', f.readline())
                 self.assertEqual('', f.readline())
 
-    def test_7_invoke_shell(self):
+    def test_invoke_shell(self):
         """
         verify that invoke_shell() does something reasonable.
         """
@@ -346,7 +346,7 @@ class TransportTest(unittest.TestCase):
         chan.close()
         self.assertEqual('', f.readline())
 
-    def test_8_channel_exception(self):
+    def test_channel_exception(self):
         """
         verify that ChannelException is thrown for a bad open-channel request.
         """
@@ -357,7 +357,7 @@ class TransportTest(unittest.TestCase):
         except ChannelException as e:
             self.assertTrue(e.code == OPEN_FAILED_ADMINISTRATIVELY_PROHIBITED)
 
-    def test_9_exit_status(self):
+    def test_exit_status(self):
         """
         verify that get_exit_status() works.
         """
@@ -386,7 +386,7 @@ class TransportTest(unittest.TestCase):
         self.assertEqual(23, chan.recv_exit_status())
         chan.close()
 
-    def test_A_select(self):
+    def test_select(self):
         """
         verify that select() on a channel works.
         """
@@ -441,7 +441,7 @@ class TransportTest(unittest.TestCase):
         # ...and now is closed.
         self.assertEqual(True, p._closed)
 
-    def test_B_renegotiate(self):
+    def test_renegotiate(self):
         """
         verify that a transport can correctly renegotiate mid-stream.
         """
@@ -465,7 +465,7 @@ class TransportTest(unittest.TestCase):
 
         schan.close()
 
-    def test_C_compression(self):
+    def test_compression(self):
         """
         verify that zlib compression is basically working.
         """
@@ -488,7 +488,7 @@ class TransportTest(unittest.TestCase):
         chan.close()
         schan.close()
 
-    def test_D_x11(self):
+    def test_x11(self):
         """
         verify that an x11 port can be requested and opened.
         """
@@ -524,7 +524,7 @@ class TransportTest(unittest.TestCase):
         chan.close()
         schan.close()
 
-    def test_E_reverse_port_forwarding(self):
+    def test_reverse_port_forwarding(self):
         """
         verify that a client can ask the server to open a reverse port for
         forwarding.
@@ -561,7 +561,7 @@ class TransportTest(unittest.TestCase):
         self.tc.cancel_port_forward('127.0.0.1', port)
         self.assertTrue(self.server._listen is None)
 
-    def test_F_port_forwarding(self):
+    def test_port_forwarding(self):
         """
         verify that a client can forward new connections from a locally-
         forwarded port.
@@ -591,7 +591,7 @@ class TransportTest(unittest.TestCase):
         self.assertEqual(b'Hello!\n', cs.recv(7))
         cs.close()
 
-    def test_G_stderr_select(self):
+    def test_stderr_select(self):
         """
         verify that select() on a channel works even if only stderr is
         receiving data.
@@ -630,7 +630,7 @@ class TransportTest(unittest.TestCase):
         schan.close()
         chan.close()
 
-    def test_H_send_ready(self):
+    def test_send_ready(self):
         """
         verify that send_ready() indicates when a send would not block.
         """
@@ -654,7 +654,7 @@ class TransportTest(unittest.TestCase):
         chan.close()
         self.assertEqual(chan.send_ready(), True)
 
-    def test_I_rekey_deadlock(self):
+    def test_rekey_deadlock(self):
         """
         Regression test for deadlock when in-transit messages are received after MSG_KEXINIT sent
 
@@ -810,7 +810,7 @@ class TransportTest(unittest.TestCase):
         schan.close()
         chan.close()
 
-    def test_J_sanitze_packet_size(self):
+    def test_sanitze_packet_size(self):
         """
         verify that we conform to the rfc of packet and window sizes.
         """
@@ -819,7 +819,7 @@ class TransportTest(unittest.TestCase):
                              (2**32, MAX_WINDOW_SIZE)]:
             self.assertEqual(self.tc._sanitize_packet_size(val), correct)
 
-    def test_K_sanitze_window_size(self):
+    def test_sanitze_window_size(self):
         """
         verify that we conform to the rfc of packet and window sizes.
         """
@@ -829,7 +829,7 @@ class TransportTest(unittest.TestCase):
             self.assertEqual(self.tc._sanitize_window_size(val), correct)
 
     @slow
-    def test_L_handshake_timeout(self):
+    def test_handshake_timeout(self):
         """
         verify that we can get a hanshake timeout.
         """
@@ -862,7 +862,7 @@ class TransportTest(unittest.TestCase):
                           username='slowdive',
                           password='pygmalion')
 
-    def test_M_select_after_close(self):
+    def test_select_after_close(self):
         """
         verify that select works when a channel is already closed.
         """


### PR DESCRIPTION
many old tests had names of form `test_[9-0A-Z]+_.*`