### PR TITLE
KexCurve25519: add is_available() method

### DIFF
--- a/paramiko/kex_curve25519.py
+++ b/paramiko/kex_curve25519.py
@@ -103,6 +103,8 @@ class KexCurve25519(object):
 
         return True
 
+    is_available = is_supported  # for compatibility with upstream's variant
+
     # ...internals...
 
     def _generate_key_pair(self):

--- a/paramiko/kex_group16.py
+++ b/paramiko/kex_group16.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2013  Torsten Landschoff <torsten@debian.org>
+# Copyright (C) 2019 Edgar Sousa <https://github.com/edgsousa>
 #
 # This file is part of paramiko.
 #


### PR DESCRIPTION
an alias of is_supported(), in order to be compatible with
upstream's (more recently added) variant