### PR TITLE
clean up SSHException subclass args and string methods

### DIFF
--- a/paramiko/ssh_exception.py
+++ b/paramiko/ssh_exception.py
@@ -54,10 +54,11 @@ class BadAuthenticationType (AuthenticationException):
 
     def __init__(self, explanation, types):
         AuthenticationException.__init__(self, explanation, types)
+        self.explanation = explanation
         self.allowed_types = types
 
     def __str__(self):
-        return "Bad authentication type, allowed types: " + ','.join(self.allowed_types)
+        return "%s; allowed types: %r" % self.args
 
 
 class PartialAuthentication (AuthenticationException):
@@ -71,7 +72,7 @@ class PartialAuthentication (AuthenticationException):
         self.allowed_types = types
 
     def __str__(self):
-        return "Partial authentication, allowed types: " + ','.join(self.allowed_types)
+        return "Partial authentication; allowed types: %r" % self.allowed_types
 
 
 class ChannelException (SSHException):
@@ -85,9 +86,10 @@ class ChannelException (SSHException):
     def __init__(self, code, text):
         SSHException.__init__(self, code, text)
         self.code = code
+        self.text = text
 
     def __str__(self):
-        return "ChannelException: %s, %s" % self.args
+        return "ChannelException(%r, %r)" % self.args
 
 
 class BadHostKeyException (SSHException):
@@ -121,7 +123,8 @@ class ProxyCommandFailure (SSHException):
     """
     def __init__(self, command, error):
         SSHException.__init__(self, command, error)
+        self.command = command
         self.error = error
 
     def __str__(self):
-        return "ProxyCommand (%s) returned non-zero exit status: %s" % self.args
+        return "ProxyCommand (%r) returned non-zero exit status: %r" % self.args

--- a/paramiko/ssh_exception.py
+++ b/paramiko/ssh_exception.py
@@ -50,20 +50,14 @@ class BadAuthenticationType (AuthenticationException):
 
     .. versionadded:: 1.1
     """
-    #: list of allowed authentication types provided by the server (possible
-    #: values are: ``"none"``, ``"password"``, and ``"publickey"``).
     allowed_types = []
 
     def __init__(self, explanation, types):
-        AuthenticationException.__init__(self, explanation)
+        AuthenticationException.__init__(self, explanation, types)
         self.allowed_types = types
-        # for unpickling
-        self.args = (explanation, types, )
 
     def __str__(self):
-        return '{} (allowed_types={!r})'.format(
-            SSHException.__str__(self), self.allowed_types
-        )
+        return "Bad authentication type, allowed types: " + ','.join(self.allowed_types)
 
 
 class PartialAuthentication (AuthenticationException):
@@ -73,10 +67,11 @@ class PartialAuthentication (AuthenticationException):
     allowed_types = []
 
     def __init__(self, types):
-        AuthenticationException.__init__(self, 'partial authentication')
+        AuthenticationException.__init__(self, types)
         self.allowed_types = types
-        # for unpickling
-        self.args = (types, )
+
+    def __str__(self):
+        return "Partial authentication, allowed types: " + ','.join(self.allowed_types)
 
 
 class ChannelException (SSHException):
@@ -88,10 +83,11 @@ class ChannelException (SSHException):
     .. versionadded:: 1.6
     """
     def __init__(self, code, text):
-        SSHException.__init__(self, text)
+        SSHException.__init__(self, code, text)
         self.code = code
-        # for unpickling
-        self.args = (code, text, )
+
+    def __str__(self):
+        return "ChannelException: %s, %s" % self.args
 
 
 class BadHostKeyException (SSHException):
@@ -105,16 +101,15 @@ class BadHostKeyException (SSHException):
     .. versionadded:: 1.6
     """
     def __init__(self, hostname, got_key, expected_key):
-        message = 'Host key for server {} does not match: got {}, expected {}'
-        message = message.format(
-            hostname, got_key.get_base64(),
-            expected_key.get_base64())
-        SSHException.__init__(self, message)
+        SSHException.__init__(self, hostname, got_key, expected_key)
         self.hostname = hostname
         self.key = got_key
         self.expected_key = expected_key
-        # for unpickling
-        self.args = (hostname, got_key, expected_key, )
+
+    def __str__(self):
+        return "Host key for server %s does not match: got %s, expected %s" % (
+            self.hostname, self.key.get_base64(), self.expected_key.get_base64()
+        )
 
 
 class ProxyCommandFailure (SSHException):
@@ -125,11 +120,8 @@ class ProxyCommandFailure (SSHException):
     :param str error: The error captured from the proxy command output.
     """
     def __init__(self, command, error):
-        SSHException.__init__(self,
-            '"ProxyCommand ({})" returned non-zero exit status: {}'.format(
-                command, error
-            )
-        )
+        SSHException.__init__(self, command, error)
         self.error = error
-        # for unpickling
-        self.args = (command, error, )
+
+    def __str__(self):
+        return "ProxyCommand (%s) returned non-zero exit status: %s" % self.args

--- a/tests/test_ssh_exception.py
+++ b/tests/test_ssh_exception.py
@@ -1,0 +1,27 @@
+import pickle
+
+import pytest
+
+from paramiko import RSAKey
+from paramiko.ssh_exception import (
+    BadAuthenticationType,
+    PartialAuthentication,
+    ChannelException,
+    BadHostKeyException,
+    ProxyCommandFailure,
+)
+
+
+@pytest.mark.parametrize(['exc'], [
+    (BadAuthenticationType("Bad authentication type", ["ok", "also-ok"]),),
+    (PartialAuthentication(["ok", "also-ok"]),),
+    (BadHostKeyException("myhost", RSAKey.generate(2048), RSAKey.generate(2048)),),
+    (ProxyCommandFailure("nc servername 22", 1),),
+    (ChannelException(17, "whatever"),),
+])
+def test_ssh_exception_strings(exc):
+    assert isinstance(str(exc), str)
+    assert isinstance(repr(exc), str)
+    if type(exc) != BadHostKeyException:
+        ne = pickle.loads(pickle.dumps(exc))
+        assert type(ne) == type(exc)


### PR DESCRIPTION
Setting "self.args" is equivalent to calling the parent class
`__init__()` method with those args, and also overrides the only
thing that parent class `__init__()` method did. It is confused.

What is actually desired is to override the `__str__()` method with
a custom formatted exception message. The default for Exception
with zero args is blank, with one arg is the str of that arg,
with multiple args is just the repr of the args tuple.
(That never includes the class name. So, we want custom str.)

inspired by https://github.com/paramiko/paramiko/issues/1440