### PR TITLE
BufferedFile: avoid quadratic buffer append with Python 3.x

### DIFF
--- a/paramiko/file.py
+++ b/paramiko/file.py
@@ -189,9 +189,9 @@ class BufferedFile (ClosingContextManager):
             raise IOError('File is not open for reading')
         if (size is None) or (size < 0):
             # go for broke
-            result = self._rbuffer
+            chunks = [self._rbuffer]
+            self._pos += len(self._rbuffer)
             self._rbuffer = bytes()
-            self._pos += len(result)
             while True:
                 try:
                     new_data = self._read(self._DEFAULT_BUFSIZE)
@@ -199,10 +199,10 @@ class BufferedFile (ClosingContextManager):
                     new_data = None
                 if (new_data is None) or (len(new_data) == 0):
                     break
-                result += new_data
+                chunks.append(new_data)
                 self._realpos += len(new_data)
                 self._pos += len(new_data)
-            return result
+            return bytes().join(chunks)
         if size <= len(self._rbuffer):
             result = self._rbuffer[:size]
             self._rbuffer = self._rbuffer[size:]


### PR DESCRIPTION
Since result is managed through repeat string
concatenation, runtime is quadratic in the number of successful
calls to read().

In Python 2 this had reasonable runtime because Python/ceval.c contained
a special case for appending to a string that could be safely mutated,
as the only reference to it existed on the stack.
("Python/ceval.c::string_concatenate()"), however during the great
Python 3.x transition this special case was rewritten to only support
Unicode, causing a huge amount of heap churn and memory copies on 3.x.

fixes paramiko/paramiko#1141
port of upstream https://github.com/paramiko/paramiko/pull/1479