### PR TITLE
kex: fix server-side of kex-group-14-sha256 and kex-group16-sha512

### DIFF
--- a/paramiko/kex_group1.py
+++ b/paramiko/kex_group1.py
@@ -130,7 +130,7 @@ class KexGroup1(object):
         hm.add_mpint(self.e)
         hm.add_mpint(self.f)
         hm.add_mpint(K)
-        H = sha1(hm.asbytes()).digest()
+        H = self.hash_algo(hm.asbytes()).digest()
         self.transport._set_K_H(K, H)
         # sign it
         sig = self.transport.get_server_key().sign_ssh_data(H)

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -137,11 +137,11 @@ class Transport(threading.Thread, ClosingContextManager):
         'ecdh-sha2-nistp384',
         'ecdh-sha2-nistp521',
         'diffie-hellman-group-exchange-sha256',
+        'diffie-hellman-group14-sha256',
+        'diffie-hellman-group16-sha512',  # some compat issues with other impls
         'diffie-hellman-group-exchange-sha1',
         'diffie-hellman-group14-sha1',
         'diffie-hellman-group1-sha1',
-        'diffie-hellman-group16-sha512',  # possibly buggy ...
-        'diffie-hellman-group14-sha256',  # some compat issues with other impls
     )
     if KexCurve25519.is_supported():
         _preferred_kex = ('curve25519-sha256@libssh.org',) + _preferred_kex


### PR DESCRIPTION
was always using sha1 instead of the appropriate hash function

fixes https://github.com/paramiko/paramiko/issues/1462
raised by https://github.com/paramiko/paramiko/issues/1455