### PR TITLE
replace issubclass() with isinstance() everywhere

### DIFF
--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -206,7 +206,7 @@ class AuthHandler (object):
             event.wait(0.1)
             if not self.transport.is_active():
                 e = self.transport.get_exception()
-                if (e is None) or issubclass(e.__class__, EOFError):
+                if e is None or isinstance(e, EOFError):
                     e = AuthenticationException('Authentication failed.')
                 raise e
             if event.is_set():
@@ -218,9 +218,7 @@ class AuthHandler (object):
             e = self.transport.get_exception()
             if e is None:
                 e = AuthenticationException('Authentication failed.')
-            # this is horrible.  Python Exception isn't yet descended from
-            # object, so type(e) won't work. :(
-            if issubclass(e.__class__, PartialAuthentication):
+            if isinstance(e, PartialAuthentication):
                 return e.allowed_types
             raise e
         return []

--- a/paramiko/packet.py
+++ b/paramiko/packet.py
@@ -544,7 +544,7 @@ class Packetizer (object):
     def _log(self, level, msg):
         if self.__logger is None:
             return
-        if issubclass(type(msg), list):
+        if isinstance(msg, list):
             for m in msg:
                 self.__logger.log(level, m)
         else:

--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -88,7 +88,7 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
         self.server = sftp_si(server, *largs, **kwargs)
 
     def _log(self, level, msg):
-        if issubclass(type(msg), list):
+        if isinstance(msg, list):
             for m in msg:
                 super(SFTPServer, self)._log(
                     level,
@@ -205,7 +205,7 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
         self._send_packet(t, msg)
 
     def _send_handle_response(self, request_number, handle, folder=False):
-        if not issubclass(type(handle), SFTPHandle):
+        if not isinstance(handle, SFTPHandle):
             # must be error code
             self._send_status(request_number, handle)
             return
@@ -229,7 +229,7 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
 
     def _open_folder(self, request_number, path):
         resp = self.server.list_folder(path)
-        if issubclass(type(resp), list):
+        if isinstance(resp, list):
             # got an actual list of filenames in the folder
             folder = SFTPHandle()
             folder._set_files(resp)
@@ -278,7 +278,7 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
             return
         if length == 0:
             st = f.stat()
-            if not issubclass(type(st), SFTPAttributes):
+            if not isinstance(st, SFTPAttributes):
                 self._send_status(request_number, st, 'Unable to stat file')
                 return
             length = st.st_size - start
@@ -410,14 +410,14 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
         elif t == CMD_STAT:
             path = msg.get_text()
             resp = self.server.stat(path)
-            if issubclass(type(resp), SFTPAttributes):
+            if isinstance(resp, SFTPAttributes):
                 self._response(request_number, CMD_ATTRS, resp)
             else:
                 self._send_status(request_number, resp)
         elif t == CMD_LSTAT:
             path = msg.get_text()
             resp = self.server.lstat(path)
-            if issubclass(type(resp), SFTPAttributes):
+            if isinstance(resp, SFTPAttributes):
                 self._response(request_number, CMD_ATTRS, resp)
             else:
                 self._send_status(request_number, resp)
@@ -428,7 +428,7 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
                     request_number, SFTP_BAD_MESSAGE, 'Invalid handle')
                 return
             resp = self.file_table[handle].stat()
-            if issubclass(type(resp), SFTPAttributes):
+            if isinstance(resp, SFTPAttributes):
                 self._response(request_number, CMD_ATTRS, resp)
             else:
                 self._send_status(request_number, resp)

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1684,7 +1684,7 @@ class Transport(threading.Thread, ClosingContextManager):
     # internals...
 
     def _log(self, level, msg, *args):
-        if issubclass(type(msg), list):
+        if isinstance(msg, list):
             for m in msg:
                 self.logger.log(level, m)
         else:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -157,9 +157,11 @@ class AuthTest (unittest.TestCase):
         try:
             self.tc.auth_password(username='slowdive', password='error')
             self.assertTrue(False)
-        except:
-            etype, evalue, etb = sys.exc_info()
-            self.assertTrue(issubclass(etype, AuthenticationException))
+        except Exception as e:
+            self.assertIsInstance(e, AuthenticationException)
+        else:
+            self.fail("AuthenticationException not thrown")
+
         self.tc.auth_password(username='slowdive', password='pygmalion')
         self.verify_finished()
 
@@ -235,9 +237,8 @@ class AuthTest (unittest.TestCase):
         self.tc.connect(hostkey=self.public_host_key)
         try:
             _ = self.tc.auth_password('bad-server', 'hello')
-        except Exception:
-            etype, evalue, etb = sys.exc_info()
-            self.assertTrue(issubclass(etype, AuthenticationException))
+        except Exception as e:
+            self.assertIsInstance(e, AuthenticationException)
         else:
             self.fail("AuthenticationException not thrown")
 
@@ -252,9 +253,8 @@ class AuthTest (unittest.TestCase):
         self.tc.connect()
         try:
             _ = self.tc.auth_password('unresponsive-server', 'hello')
-        except Exception:
-            etype, evalue, etb = sys.exc_info()
-            self.assertTrue(issubclass(etype, AuthenticationException))
-            self.assertTrue('Authentication timeout' in str(evalue))
+        except Exception as e:
+            self.assertIsInstance(e, AuthenticationException)
+            self.assertTrue('Authentication timeout' in str(e))
         else:
             self.fail("AuthenticationException not thrown")


### PR DESCRIPTION
issubclass() was being used in odd ways, probably due to
limitations in very old versions of python (no longer supported)

inspired by https://github.com/paramiko/paramiko/pull/1550