### PR TITLE
RSAKey: add support for rsa-sha2-256 and rsa-sha2-512 from RFC8332

### DIFF
--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -117,16 +117,21 @@ class RSAKey(PKey):
         return m
 
     def verify_ssh_sig(self, data, msg):
-        if msg.get_text() != 'ssh-rsa':
+        key_algorithm = msg.get_text()
+        if key_algorithm == "ssh-rsa":
+            algorithm = hashes.SHA1()
+        elif key_algorithm == "rsa-sha2-256":
+            algorithm = hashes.SHA256()
+        elif key_algorithm == "rsa-sha2-512":
+            algorithm = hashes.SHA512()
+        else:
             return False
         key = self.key
         if isinstance(key, rsa.RSAPrivateKey):
             key = key.public_key()
 
         try:
-            key.verify(
-                msg.get_binary(), data, padding.PKCS1v15(), hashes.SHA1()
-            )
+            key.verify(msg.get_binary(), data, padding.PKCS1v15(), algorithm)
         except InvalidSignature:
             return False
         else:

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -215,6 +215,8 @@ class Transport(threading.Thread, ClosingContextManager):
 
     _key_info = {
         'ssh-rsa': RSAKey,
+        'rsa-sha2-256': RSAKey,
+        'rsa-sha2-512': RSAKey,
         'ssh-rsa-cert-v01@openssh.com': RSAKey,
         'ssh-dss': DSSKey,
         'ssh-dss-cert-v01@openssh.com': DSSKey,


### PR DESCRIPTION
signature schemes for RSA keys using sha2 instead of sha1

ref: https://tools.ietf.org/rfc/rfc8332.txt

port of https://github.com/paramiko/paramiko/pull/1520