### PR TITLE
Add functions to auto-detect and load any private key type

### DIFF
--- a/demos/demo.py
+++ b/demos/demo.py
@@ -57,31 +57,20 @@ def agent_auth(transport, username):
 
 def manual_auth(username, hostname):
     default_auth = 'p'
-    auth = input('Auth by (p)assword, (r)sa key, or (d)ss key? [%s] ' % default_auth)
+    auth = input('Auth by (p)assword or (k)ey file? [%s] ' % default_auth)
     if len(auth) == 0:
         auth = default_auth
 
-    if auth == 'r':
+    if auth == 'k':
         default_path = os.path.join(os.environ['HOME'], '.ssh', 'id_rsa')
-        path = input('RSA key [%s]: ' % default_path)
+        path = input('Private key file [%s]: ' % default_path)
         if len(path) == 0:
             path = default_path
         try:
-            key = paramiko.RSAKey.from_private_key_file(path)
+            key = paramiko.load_private_key_file(path)
         except paramiko.PasswordRequiredException:
-            password = getpass.getpass('RSA key password: ')
-            key = paramiko.RSAKey.from_private_key_file(path, password)
-        t.auth_publickey(username, key)
-    elif auth == 'd':
-        default_path = os.path.join(os.environ['HOME'], '.ssh', 'id_dsa')
-        path = input('DSS key [%s]: ' % default_path)
-        if len(path) == 0:
-            path = default_path
-        try:
-            key = paramiko.DSSKey.from_private_key_file(path)
-        except paramiko.PasswordRequiredException:
-            password = getpass.getpass('DSS key password: ')
-            key = paramiko.DSSKey.from_private_key_file(path, password)
+            password = getpass.getpass('Private key password: ')
+            key = paramiko.load_private_key_file(path, password)
         t.auth_publickey(username, key)
     else:
         pw = getpass.getpass('Password for %s@%s: ' % (username, hostname))

--- a/demos/demo_server.py
+++ b/demos/demo_server.py
@@ -31,8 +31,7 @@ from paramiko.py3compat import u, decodebytes
 # setup logging
 paramiko.util.log_to_file('demo_server.log')
 
-host_key = paramiko.RSAKey(filename='test_rsa.key')
-# host_key = paramiko.DSSKey(filename='test_dss.key')
+host_key = paramiko.load_private_key_file('test_rsa.key')
 
 print('Read key: ' + u(hexlify(host_key.get_fingerprint())))
 

--- a/paramiko/__init__.py
+++ b/paramiko/__init__.py
@@ -48,7 +48,12 @@ from paramiko.message import Message
 from paramiko.packet import Packetizer
 from paramiko.file import BufferedFile
 from paramiko.agent import Agent, AgentKey
-from paramiko.pkey import PKey, PublicBlob
+from paramiko.pkey import (
+    PKey,
+    PublicBlob,
+    load_private_key,
+    load_private_key_file,
+)
 from paramiko.hostkeys import HostKeys
 from paramiko.config import SSHConfig
 from paramiko.proxy import ProxyCommand

--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -26,26 +26,31 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa, padding
 
 from paramiko.message import Message
-from paramiko.pkey import PKey
+from paramiko.pkey import PKey, register_pkey_type
 from paramiko.py3compat import PY2
 from paramiko.ssh_exception import SSHException
 
 
+@register_pkey_type
 class RSAKey(PKey):
     """
     Representation of an RSA key which can be used to sign and verify SSH2
     data.
     """
 
+    LEGACY_TYPE = "RSA"
+    OPENSSH_TYPE_PREFIX = "ssh-rsa"
+
     def __init__(self, msg=None, data=None, filename=None, password=None,
-                 key=None, file_obj=None):
+                 key=None, file_obj=None, _raw=None):
         self.key = None
         self.public_blob = None
         if file_obj is not None:
-            self._from_private_key(file_obj, password)
-            return
+            _raw = self._from_private_key(file_obj, password)
         if filename is not None:
-            self._from_private_key_file(filename, password)
+            _raw = self._from_private_key_file(filename, password)
+        if _raw is not None:
+            self._decode_key(_raw)
             return
         if (msg is None) and (data is not None):
             msg = Message(data)
@@ -164,15 +169,6 @@ class RSAKey(PKey):
         return RSAKey(key=key)
 
     # ...internals...
-
-    def _from_private_key_file(self, filename, password):
-        data = self._read_private_key_file('RSA', 'ssh-rsa', filename, password)
-        self._decode_key(data)
-
-    def _from_private_key(self, file_obj, password):
-        data = self._read_private_key('RSA', 'ssh-rsa', file_obj, password)
-        self._decode_key(data)
-
     def _decode_key(self, data):
         pkformat, data = data
         if pkformat == self.FORMAT_ORIGINAL:

--- a/sites/docs/api/keys.rst
+++ b/sites/docs/api/keys.rst
@@ -6,6 +6,7 @@ Parent key class
 ================
 
 .. automodule:: paramiko.pkey
+    :member-order: bysource
 
 DSA (DSS)
 =========

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import shutil
 import threading
 
 import pytest
-from paramiko import RSAKey, SFTPServer, SFTP, Transport
+from paramiko import SFTPServer, SFTP, Transport, load_private_key_file
 
 from .loop import LoopSocket
 from .stub_sftp import StubServer, StubSFTPServer
@@ -69,7 +69,7 @@ def sftp_server():
     tc = Transport(sockc)
     ts = Transport(socks)
     # Auth
-    host_key = RSAKey.from_private_key_file(_support('test_rsa.key'))
+    host_key = load_private_key_file(_support('test_rsa.key'))
     ts.add_server_key(host_key)
     # Server setup
     event = threading.Event()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -26,8 +26,8 @@ import unittest
 from time import sleep
 
 from paramiko import (
-    Transport, ServerInterface, RSAKey, DSSKey, BadAuthenticationType,
-    InteractiveQuery, AuthenticationException,
+    Transport, ServerInterface, RSAKey, BadAuthenticationType,
+    InteractiveQuery, AuthenticationException, load_private_key_file,
 )
 from paramiko import AUTH_FAILED, AUTH_PARTIALLY_SUCCESSFUL, AUTH_SUCCESSFUL
 
@@ -41,7 +41,7 @@ _pwd = u'\u2022'
 class NullServer (ServerInterface):
     paranoid_did_password = False
     paranoid_did_public_key = False
-    paranoid_key = DSSKey.from_private_key_file(_support('test_dss.key'))
+    paranoid_key = load_private_key_file(_support('test_dss.key'))
 
     def get_allowed_auths(self, username):
         if username == 'slowdive':
@@ -119,7 +119,7 @@ class AuthTest (unittest.TestCase):
         self.sockc.close()
 
     def start_server(self):
-        host_key = RSAKey.from_private_key_file(_support('test_rsa.key'))
+        host_key = load_private_key_file(_support('test_rsa.key'))
         self.public_host_key = RSAKey(data=host_key.asbytes())
         self.ts.add_server_key(host_key)
         self.event = threading.Event()
@@ -173,7 +173,7 @@ class AuthTest (unittest.TestCase):
         self.tc.connect(hostkey=self.public_host_key)
         remain = self.tc.auth_password(username='paranoid', password='paranoid')
         self.assertEqual(['publickey'], remain)
-        key = DSSKey.from_private_key_file(_support('test_dss.key'))
+        key = load_private_key_file(_support('test_dss.key'))
         remain = self.tc.auth_publickey(username='paranoid', key=key)
         self.assertEqual([], remain)
         self.verify_finished()

--- a/tests/test_kex_gss.py
+++ b/tests/test_kex_gss.py
@@ -80,7 +80,7 @@ class GSSKexTest(KerberosTestCase):
     def _run(self):
         self.socks, addr = self.sockl.accept()
         self.ts = paramiko.Transport(self.socks, gss_kex=True)
-        host_key = paramiko.RSAKey.from_private_key_file('tests/test_rsa.key')
+        host_key = paramiko.load_private_key_file('tests/test_rsa.key')
         self.ts.add_server_key(host_key)
         self.ts.set_gss_host(self.realm.hostname)
         try:
@@ -96,7 +96,7 @@ class GSSKexTest(KerberosTestCase):
         Diffie-Hellman Key Exchange and user authentication with the GSS-API
         context created during key exchange.
         """
-        host_key = paramiko.RSAKey.from_private_key_file('tests/test_rsa.key')
+        host_key = paramiko.load_private_key_file('tests/test_rsa.key')
         public_host_key = paramiko.RSAKey(data=host_key.asbytes())
 
         self.tc = paramiko.SSHClient()

--- a/tests/test_ssh_gss.py
+++ b/tests/test_ssh_gss.py
@@ -91,7 +91,7 @@ class GSSAuthTest(KerberosTestCase):
     def _run(self):
         self.socks, addr = self.sockl.accept()
         self.ts = paramiko.Transport(self.socks)
-        host_key = paramiko.RSAKey.from_private_key_file('tests/test_rsa.key')
+        host_key = paramiko.load_private_key_file('tests/test_rsa.key')
         self.ts.add_server_key(host_key)
         server = NullServer()
         self.ts.start_server(self.event, server)
@@ -102,7 +102,7 @@ class GSSAuthTest(KerberosTestCase):
 
         The exception is ... no exception yet
         """
-        host_key = paramiko.RSAKey.from_private_key_file('tests/test_rsa.key')
+        host_key = paramiko.load_private_key_file('tests/test_rsa.key')
         public_host_key = paramiko.RSAKey(data=host_key.asbytes())
 
         self.tc = paramiko.SSHClient()


### PR DESCRIPTION
Two new functions were created:
* load_private_key(key_str, password=None)
* load_private_key_file(filename, password=None)

Previously there was no way to auto-load any key type. Many downstream
users re-implemented this logic themselves, which is pointless
duplication and could easily become outdated when new key types are
added.

This functionality required a significant refactoring of key creation
code paths, but none of the public interfaces have changed.