### PR TITLE
pkey: fix loading original format with leading whitespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
 branches:
   only:
   - master
+  - 2.6
 notifications:
   email: false
 

--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -325,18 +325,17 @@ class PKey(object):
             data = self._read_private_key_new_format(typepfx, lines[start:end], password)
             pkformat = self.FORMAT_OPENSSH
         elif keytype == tag:
-            data = self._read_private_key_old_format(lines, end, password)
+            data = self._read_private_key_old_format(lines[start:end], password)
             pkformat = self.FORMAT_ORIGINAL
         else:
             raise SSHException('encountered {} key, expected {} key'.format(keytype, tag))
 
         return pkformat, data
 
-    def _read_private_key_old_format(self, lines, end, password):
-        start = 0
+    def _read_private_key_old_format(self, lines, password):
         # parse any headers first
+        start = 0
         headers = {}
-        start += 1
         while start < len(lines):
             l = lines[start].split(': ')
             if len(l) == 1:
@@ -345,7 +344,7 @@ class PKey(object):
             start += 1
         # if we trudged to the end of the file, just try to cope.
         try:
-            data = decodebytes(b(''.join(lines[start:end])))
+            data = decodebytes(b(''.join(lines[start:])))
         except base64.binascii.Error as e:
             raise SSHException('base64 decoding error: ' + str(e))
         if 'proc-type' not in headers:

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -465,6 +465,11 @@ class KeyTest(unittest.TestCase):
         my_fp = hexlify(key.get_fingerprint())
         self.assertEqual(exp_fp, my_fp)
 
+    def test_leading_whitespace(self):
+        key1 = RSAKey.from_private_key(StringIO("\n\n" + RSA_PRIVATE_OUT + "\n\n"))
+        key2 = RSAKey.from_private_key(StringIO(RSA_PRIVATE_OUT))
+        self.assertEqual(key1.get_fingerprint(), key2.get_fingerprint())
+
     def test_salt_size(self):
         # Read an existing encrypted private key
         file_ = _support('test_rsa_password.key')


### PR DESCRIPTION
accidentally broken when adding new openssh format private key support

fixes https://github.com/paramiko/paramiko/issues/1580