### PR TITLE
SSHClient: add handshake_timeout kwarg to connect()

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -205,6 +205,7 @@ class SSHClient (ClosingContextManager):
         auth_timeout=None,
         gss_trust_dns=True,
         passphrase=None,
+        handshake_timeout=None,
     ):
         """
         Connect to an SSH server and authenticate to it.  The server's host key
@@ -239,6 +240,9 @@ class SSHClient (ClosingContextManager):
         If a private key requires a password to unlock it, and a password is
         passed in, that password will be used to attempt to unlock the key.
 
+        Note that the following parameters are documented in a different
+        (more logical) order than they have in the function signature.
+
         :param str hostname: the server to connect to
         :param int port: the server port to connect to
         :param str username:
@@ -253,13 +257,20 @@ class SSHClient (ClosingContextManager):
         :param str key_filename:
             the filename, or list of filenames, of optional private key(s)
             and/or certs to try for authentication
-        :param float timeout:
-            an optional timeout (in seconds) for the TCP connect
-        :param bool allow_agent:
-            set to False to disable connecting to the SSH agent
         :param bool look_for_keys:
             set to False to disable searching for discoverable private key
             files in ``~/.ssh/``
+        :param bool allow_agent:
+            set to False to disable connecting to the SSH agent
+        :param float timeout:
+            an optional timeout (in seconds) for the overall SSH session
+            negotiation (also applies to the TCP connection)
+        :param float banner_timeout: an optional timeout (in seconds) to wait
+            for the SSH banner to be presented.
+        :param float handshake_timeout: an optional timeout (in seconds) to wait
+            for the SSH handshake to finish after SSH banner exchange.
+        :param float auth_timeout: an optional timeout (in seconds) to wait for
+            an authentication response.
         :param bool compress: set to True to turn on compression
         :param socket sock:
             an open socket or socket-like object (such as a `.Channel`) to use
@@ -275,10 +286,6 @@ class SSHClient (ClosingContextManager):
             Indicates whether or not the DNS is trusted to securely
             canonicalize the name of the host being connected to (default
             ``True``).
-        :param float banner_timeout: an optional timeout (in seconds) to wait
-            for the SSH banner to be presented.
-        :param float auth_timeout: an optional timeout (in seconds) to wait for
-            an authentication response.
 
         :raises:
             `.BadHostKeyException` -- if the server's host key could not be
@@ -292,10 +299,14 @@ class SSHClient (ClosingContextManager):
         .. versionchanged:: 1.15
             Added the ``banner_timeout``, ``gss_auth``, ``gss_kex``,
             ``gss_deleg_creds`` and ``gss_host`` arguments.
+        .. versionchanged:: 2.2
+            Added the ``auth_timeout`` argument.
         .. versionchanged:: 2.3
             Added the ``gss_trust_dns`` argument.
         .. versionchanged:: 2.4
             Added the ``passphrase`` argument.
+        .. versionchanged:: 2.9
+            Added the ``handshake_timeout`` argument.
         """
         if not sock:
             sock = retry_on_signal(
@@ -317,6 +328,8 @@ class SSHClient (ClosingContextManager):
             t.set_log_channel(self._log_channel)
         if banner_timeout is not None:
             t.banner_timeout = banner_timeout
+        if handshake_timeout is not None:
+            t.handshake_timeout = handshake_timeout
         if auth_timeout is not None:
             t.auth_timeout = auth_timeout
 

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -404,12 +404,12 @@ class Transport(threading.Thread, ClosingContextManager):
         # user-defined event callbacks
         self.completion_event = None
         # how long (seconds) to wait for the SSH banner
-        self.banner_timeout = 15
+        self.banner_timeout = 15.0
         # how long (seconds) to wait for the handshake to finish after SSH
         # banner sent.
-        self.handshake_timeout = 15
+        self.handshake_timeout = 15.0
         # how long (seconds) to wait for the auth response.
-        self.auth_timeout = 30
+        self.auth_timeout = 30.0
         # AuthHandler to save MSG_USERAUTH_BANNER msg here
         self.banner = None
 
@@ -1912,8 +1912,6 @@ class Transport(threading.Thread, ClosingContextManager):
                 # responding, for example when the remote ssh daemon is loaded
                 # in to memory but we can not read from the disk/spawn a new
                 # shell.
-                # Make sure we can specify a timeout for the initial handshake.
-                # Re-use the banner timeout for now.
                 self.packetizer.start_handshake(self.handshake_timeout)
                 self._send_kex_init()
                 self._expect_packet(MSG_KEXINIT)

--- a/sites/docs/conf.py
+++ b/sites/docs/conf.py
@@ -38,7 +38,10 @@ source_suffix = '.rst'
 default_role = 'obj'
 
 # Autodoc settings
-autodoc_default_flags = ['members', 'special-members']
+autodoc_default_options = {
+    'members': True,
+    'special-members': True,
+}
 
 # Intersphinx connection to stdlib
 intersphinx_mapping = {


### PR DESCRIPTION
Also update connect() documentation - note when auth_timeout
was added, and re-order params in the docs a bit
(the order already differed from the function signature,
which keeps the original order for now).