### PR TITLE
call setsid() in ProxyCommand subprocess

### DIFF
--- a/paramiko/proxy.py
+++ b/paramiko/proxy.py
@@ -50,7 +50,7 @@ class ProxyCommand(ClosingContextManager):
         from subprocess import Popen, PIPE
         self.cmd = command_line
         self.process = Popen(self.cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE,
-                             bufsize=0, shell=True)
+                             bufsize=0, shell=True, preexec_fn=os.setsid)
         self.timeout = None
 
     def send(self, content):


### PR DESCRIPTION
so that signals sent to the foreground process group
are not also received by the ProxyCommand
(it should be closed by the transport when the parent shuts down)

inspired by https://github.com/paramiko/paramiko/pull/1183