### PR TITLE
logging reform: Transport,SFTP* _log() refactor

### DIFF
--- a/demos/demo.py
+++ b/demos/demo.py
@@ -46,7 +46,7 @@ def agent_auth(transport, username):
         return
 
     for key in agent_keys:
-        print('Trying ssh-agent key %s' % hexlify(key.get_fingerprint()))
+        print('Trying ssh-agent key %s' % hexlify(key.get_fingerprint()).decode())
         try:
             transport.auth_publickey(username, key)
             print('... success!')

--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -70,8 +70,8 @@ class AuthHandler (object):
         self.gss_host = None
         self.gss_deleg_creds = True
 
-    def _log(self, *args):
-        return self.transport._log(*args)
+    def _log(self, level, msg):
+        return self.transport._log(level, "%s", msg)
 
     def is_authenticated(self):
         return self.authenticated
@@ -611,7 +611,7 @@ Error Message: {}
     def _parse_userauth_banner(self, m):
         banner = m.get_string()
         self.transport.banner = banner
-        self._log(INFO, 'Auth banner: {}'.format(banner))
+        self._log(INFO, "Auth banner: {!r}".format(banner))
         # who cares.
 
     def _parse_userauth_info_request(self, m):

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -511,7 +511,7 @@ class SSHClient (ClosingContextManager):
         # when #387 is released, since this is a critical log message users are
         # likely testing/filtering for (bah.)
         msg = "Trying discovered key {} in {}".format(
-            hexlify(key.get_fingerprint()), key_path,
+            hexlify(key.get_fingerprint()).decode(), key_path,
         )
         self._log(DEBUG, msg)
         # Attempt to load cert if it exists.
@@ -581,10 +581,7 @@ class SSHClient (ClosingContextManager):
 
         if pkey is not None and 'publickey' in allowed_types:
             try:
-                self._log(
-                    DEBUG,
-                    'Trying SSH key {}'.format(hexlify(pkey.get_fingerprint()))
-                )
+                self._log(DEBUG, "Trying SSH key %s" % hexlify(pkey.get_fingerprint()).decode())
                 allowed_types = set(
                     self._transport.auth_publickey(username, pkey))
                 two_factor = (allowed_types & two_factor_types)
@@ -612,8 +609,8 @@ class SSHClient (ClosingContextManager):
 
             for key in self._agent.get_keys():
                 try:
-                    id_ = hexlify(key.get_fingerprint())
-                    self._log(DEBUG, 'Trying SSH agent key {}'.format(id_))
+                    self._log(DEBUG, "Trying SSH agent key %s"
+                              % hexlify(key.get_fingerprint()).decode())
                     allowed_types = set(
                         self._transport.auth_publickey(username, key))
                     two_factor = (allowed_types & two_factor_types)
@@ -684,7 +681,7 @@ class SSHClient (ClosingContextManager):
         raise SSHException('No authentication methods available')
 
     def _log(self, level, msg):
-        self._transport._log(level, msg)
+        self._transport._log(level, "%s", msg)
 
 
 class MissingHostKeyPolicy (object):
@@ -719,7 +716,7 @@ class AutoAddPolicy (MissingHostKeyPolicy):
         if client._host_keys_filename is not None:
             client.save_host_keys(client._host_keys_filename)
         client._log(DEBUG, 'Adding {} host key for {}: {}'.format(
-            key.get_name(), hostname, hexlify(key.get_fingerprint()),
+            key.get_name(), hostname, hexlify(key.get_fingerprint()).decode(),
         ))
 
 
@@ -731,7 +728,7 @@ class RejectPolicy (MissingHostKeyPolicy):
 
     def missing_host_key(self, client, hostname, key):
         client._log(DEBUG, 'Rejecting {} host key for {}: {}'.format(
-            key.get_name(), hostname, hexlify(key.get_fingerprint()),
+            key.get_name(), hostname, hexlify(key.get_fingerprint()).decode(),
         ))
         raise SSHException(
             'Server {!r} not found in known_hosts'.format(hostname)
@@ -745,5 +742,5 @@ class WarningPolicy (MissingHostKeyPolicy):
     """
     def missing_host_key(self, client, hostname, key):
         warnings.warn('Unknown {} host key for {}: {}'.format(
-            key.get_name(), hostname, hexlify(key.get_fingerprint()),
+            key.get_name(), hostname, hexlify(key.get_fingerprint()).decode(),
         ))

--- a/paramiko/kex_gex.py
+++ b/paramiko/kex_gex.py
@@ -137,14 +137,10 @@ class KexGex (object):
         # generate prime
         pack = self.transport._get_modulus_pack()
         if pack is None:
-            raise SSHException(
-                'Can\'t do server-side gex with no modulus pack')
-        self.transport._log(
-            DEBUG,
-            'Picking p ({} <= {} <= {} bits)'.format(
-                minbits, preferredbits, maxbits,
-            )
-        )
+            raise SSHException("Can't do server-side gex with no modulus pack")
+
+        self.transport._log(DEBUG, "Picking p (%s <= %s <= %s bits)",
+                            minbits, preferredbits, maxbits)
         self.g, self.p = pack.get_modulus(minbits, preferredbits, maxbits)
         m = Message()
         m.add_byte(c_MSG_KEXDH_GEX_GROUP)

--- a/paramiko/kex_gss.py
+++ b/paramiko/kex_gss.py
@@ -414,14 +414,10 @@ class KexGSSGex(object):
         # generate prime
         pack = self.transport._get_modulus_pack()
         if pack is None:
-            raise SSHException(
-                'Can\'t do server-side gex with no modulus pack')
-        self.transport._log(
-            DEBUG,  # noqa
-            'Picking p ({} <= {} <= {} bits)'.format(
-                minbits, preferredbits, maxbits,
-            )
-        )
+            raise SSHException("Can't do server-side gex with no modulus pack")
+
+        self.transport._log(DEBUG, "Picking p (%s <= %s <= %s bits)",
+                            minbits, preferredbits, maxbits)
         self.g, self.p = pack.get_modulus(minbits, preferredbits, maxbits)
         m = Message()
         m.add_byte(c_MSG_KEXGSS_GROUP)
@@ -444,7 +440,7 @@ class KexGSSGex(object):
             raise SSHException(
                 'Server-generated gex p (don\'t ask) is out of range '
                 '({} bits)'.format(bitlen))
-        self.transport._log(DEBUG, 'Got server p ({} bits)'.format(bitlen))  # noqa
+        self.transport._log(DEBUG, "Got server p (%s bits)", bitlen)
         self._generate_x()
         # now compute e = g^x mod p
         self.e = pow(self.g, self.x, self.p)

--- a/paramiko/server.py
+++ b/paramiko/server.py
@@ -21,7 +21,6 @@
 """
 
 import threading
-from paramiko import util
 from paramiko.common import (
     DEBUG, ERROR, OPEN_FAILED_ADMINISTRATIVELY_PROHIBITED, AUTH_FAILED,
     AUTH_SUCCESSFUL,
@@ -667,18 +666,11 @@ class SubsystemHandler (threading.Thread):
 
     def _run(self):
         try:
-            self.__transport._log(
-                DEBUG, 'Starting handler for subsystem {}'.format(self.__name)
-            )
+            self.__transport._log(DEBUG, "Starting handler for subsystem %s", self.__name)
             self.start_subsystem(self.__name, self.__transport, self.__channel)
         except Exception as e:
-            self.__transport._log(
-                ERROR,
-                'Exception in subsystem handler for "{}": {}'.format(
-                    self.__name, e
-                )
-            )
-            self.__transport._log(ERROR, util.tb_strings())
+            self.__transport._log(ERROR, 'Exception in subsystem handler for "%s": %s',
+                                  self.__name, e, exc_info=True)
         try:
             self.finish_subsystem()
         except:

--- a/paramiko/sftp.py
+++ b/paramiko/sftp.py
@@ -127,8 +127,12 @@ class BaseSFTP (object):
         self._send_packet(CMD_VERSION, msg)
         return version
 
-    def _log(self, level, msg, *args):
-        self.logger.log(level, msg, *args)
+    def _log(self, level, msg, *args, **kwargs):
+        self.logger.log(level, msg, *args, **kwargs)
+
+    def _loglist(self, level, msgs):
+        for m in msgs:
+            self._log(level, "%s", m)
 
     def _write_all(self, out):
         while len(out) > 0:
@@ -167,7 +171,7 @@ class BaseSFTP (object):
         packet = asbytes(packet)
         out = struct.pack('>I', len(packet) + 1) + byte_chr(t) + packet
         if self.ultra_debug:
-            self._log(DEBUG, util.format_binary(out, 'OUT: '))
+            self._loglist(DEBUG, util.format_binary(out, 'OUT: '))
         self._write_all(out)
 
     def _read_packet(self):
@@ -179,7 +183,7 @@ class BaseSFTP (object):
         size = struct.unpack('>I', x)[0]
         data = self._read_all(size)
         if self.ultra_debug:
-            self._log(DEBUG, util.format_binary(data, 'IN: '))
+            self._loglist(DEBUG, util.format_binary(data, 'IN: '))
         if size > 0:
             t = byte_ord(data[0])
             return t, data[1:]

--- a/paramiko/sftp_file.py
+++ b/paramiko/sftp_file.py
@@ -28,7 +28,7 @@ import time
 from paramiko.common import DEBUG
 
 from paramiko.file import BufferedFile
-from paramiko.py3compat import u, long
+from paramiko.py3compat import long
 from paramiko.sftp import (
     CMD_CLOSE, CMD_READ, CMD_DATA, SFTPError, CMD_WRITE, CMD_STATUS, CMD_FSTAT,
     CMD_ATTRS, CMD_FSETSTAT, CMD_EXTENDED,
@@ -81,7 +81,7 @@ class SFTPFile (BufferedFile):
         # __del__.)
         if self._closed:
             return
-        self.sftp._log(DEBUG, 'close({})'.format(u(hexlify(self.handle))))
+        self.sftp._log(DEBUG, "close(%s)", hexlify(self.handle).decode())
         if self.pipelined:
             self.sftp._finish_responses(self)
         BufferedFile.close(self)
@@ -286,8 +286,7 @@ class SFTPFile (BufferedFile):
 
         :param int mode: new permissions
         """
-        self.sftp._log(DEBUG, 'chmod({}, {!r})'.format(
-            hexlify(self.handle), mode))
+        self.sftp._log(DEBUG, "chmod(%s, %r)", hexlify(self.handle).decode(), mode)
         attr = SFTPAttributes()
         attr.st_mode = mode
         self.sftp._request(CMD_FSETSTAT, self.handle, attr)
@@ -302,9 +301,7 @@ class SFTPFile (BufferedFile):
         :param int uid: new owner's uid
         :param int gid: new group id
         """
-        self.sftp._log(
-            DEBUG,
-            'chown({}, {!r}, {!r})'.format(hexlify(self.handle), uid, gid))
+        self.sftp._log(DEBUG, "chown(%s, %r, %r)", hexlify(self.handle).decode(), uid, gid)
         attr = SFTPAttributes()
         attr.st_uid, attr.st_gid = uid, gid
         self.sftp._request(CMD_FSETSTAT, self.handle, attr)
@@ -324,8 +321,7 @@ class SFTPFile (BufferedFile):
         """
         if times is None:
             times = (time.time(), time.time())
-        self.sftp._log(DEBUG, 'utime({}, {!r})'.format(
-            hexlify(self.handle), times))
+        self.sftp._log(DEBUG, "utime(%s, %r)", hexlify(self.handle).decode(), times)
         attr = SFTPAttributes()
         attr.st_atime, attr.st_mtime = times
         self.sftp._request(CMD_FSETSTAT, self.handle, attr)
@@ -338,9 +334,7 @@ class SFTPFile (BufferedFile):
 
         :param size: the new size of the file
         """
-        self.sftp._log(
-            DEBUG,
-            'truncate({}, {!r})'.format(hexlify(self.handle), size))
+        self.sftp._log(DEBUG, "truncate(%s, %r)", hexlify(self.handle).decode(), size)
         attr = SFTPAttributes()
         attr.st_size = size
         self.sftp._request(CMD_FSETSTAT, self.handle, attr)
@@ -473,8 +467,7 @@ class SFTPFile (BufferedFile):
 
         .. versionadded:: 1.5.4
         """
-        self.sftp._log(DEBUG, 'readv({}, {!r})'.format(
-            hexlify(self.handle), chunks))
+        self.sftp._log(DEBUG, "readv(%s, %r)", hexlify(self.handle).decode(), chunks)
 
         read_chunks = []
         for offset, size in chunks:

--- a/paramiko/util.py
+++ b/paramiko/util.py
@@ -21,14 +21,12 @@ Useful functions used by the rest of paramiko.
 """
 
 import errno
-import sys
 import struct
-import traceback
 import threading
 import logging
 
 from paramiko.common import DEBUG, zero_byte, xffffffff, max_byte
-from paramiko.py3compat import PY2, long, byte_chr, byte_ord, b
+from paramiko.py3compat import PY2, long, byte_ord, b
 from paramiko.config import SSHConfig
 
 
@@ -108,17 +106,6 @@ def format_binary_line(data):
     return '{:50s} {}'.format(left, right)
 
 
-def safe_string(s):
-    out = b''
-    for c in s:
-        i = byte_ord(c)
-        if 32 <= i <= 127:
-            out += byte_chr(i)
-        else:
-            out += b('%{:02X}'.format(i))
-    return out
-
-
 def bit_length(n):
     try:
         return n.bit_length()
@@ -132,10 +119,6 @@ def bit_length(n):
             hbyte <<= 1
             bitlen -= 1
         return bitlen
-
-
-def tb_strings():
-    return ''.join(traceback.format_exception(*sys.exc_info())).split('\n')
 
 
 def generate_key_bytes(hash_alg, salt, key, nbytes):

--- a/tests/test_kex.py
+++ b/tests/test_kex.py
@@ -120,7 +120,7 @@ class FakeTransport(object):
     def _activate_outbound(self):
         self._activated = True
 
-    def _log(self, level, s):
+    def _log(self, level, msg, *args):
         pass
 
     def get_server_key(self):

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -721,23 +721,6 @@ class TestSFTP(object):
         finally:
             sftp.remove(target)
 
-    # TODO: this test doesn't actually fail if the regression (removing '%'
-    # expansion to '%%' within sftp.py's def _log()) is removed - stacktraces
-    # appear but they're clearly emitted from subthreads that have no error
-    # handling. No point running it until that is fixed somehow.
-    @pytest.mark.skip("Doesn't prove anything right now")
-    def test_file_with_percent(self, sftp):
-        """
-        verify that we can create a file with a '%' in the filename.
-        ( it needs to be properly escaped by _log() )
-        """
-        f = sftp.open(sftp.FOLDER + '/test%file', 'w')
-        try:
-            assert f.stat().st_size == 0
-        finally:
-            f.close()
-            sftp.remove(sftp.FOLDER + '/test%file')
-
     def test_non_utf8_data(self, sftp):
         """Test write() and read() of non utf8 data"""
         try:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -28,7 +28,7 @@ import unittest
 import textwrap
 
 import paramiko.util
-from paramiko.util import lookup_ssh_host_config as host_config, safe_string
+from paramiko.util import lookup_ssh_host_config as host_config
 from paramiko.py3compat import StringIO, byte_ord
 
 
@@ -451,18 +451,6 @@ Host param3 parara
             )
         for host in incorrect_data:
             self.assertRaises(Exception, conf._get_hosts, host)
-
-    def test_safe_string(self):
-        vanilla = b"vanilla"
-        has_bytes = b"has \7\3 bytes"
-        safe_vanilla = safe_string(vanilla)
-        safe_has_bytes = safe_string(has_bytes)
-        expected_bytes = b"has %07%03 bytes"
-        err = "{!r} != {!r}"
-        msg = err.format(safe_vanilla, vanilla)
-        assert safe_vanilla == vanilla, msg
-        msg = err.format(safe_has_bytes, expected_bytes)
-        assert safe_has_bytes == expected_bytes, msg
 
     def test_proxycommand_none_issue_418(self):
         test_config_file = """


### PR DESCRIPTION
Transport._log() does not take msg list, it takes format string

SFTPClient/SFTPServer _log() method does not take msg list
SFTPBase gets new _loglist() method for the rare list case

Transport and SFTP* use proper logging format strings
and separate arguments

SSHClient and AuthHandler always log with single msg string,
so pass to Transport._log() as "%s", msg

get rid of util.tb_strings(), instead _log() with exc_info=True
so that lines of traceback are not separate log messages
(inspired by https://github.com/paramiko/paramiko/pull/406)