### PR TITLE
add paramiko.__pkgname__ to help distinguish from upstream paramiko

### DIFF
--- a/paramiko/__init__.py
+++ b/paramiko/__init__.py
@@ -18,7 +18,6 @@
 # along with Paramiko; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
 
-from paramiko._version import __version__, __version_info__
 from paramiko.transport import SecurityOptions, Transport
 from paramiko.client import (
     SSHClient, MissingHostKeyPolicy, AutoAddPolicy, RejectPolicy,
@@ -57,28 +56,25 @@ from paramiko.pkey import (
 from paramiko.hostkeys import HostKeys
 from paramiko.config import SSHConfig
 from paramiko.proxy import ProxyCommand
-
+from paramiko.common import io_sleep
 from paramiko.common import (
     AUTH_SUCCESSFUL, AUTH_PARTIALLY_SUCCESSFUL, AUTH_FAILED, OPEN_SUCCEEDED,
     OPEN_FAILED_ADMINISTRATIVELY_PROHIBITED, OPEN_FAILED_CONNECT_FAILED,
     OPEN_FAILED_UNKNOWN_CHANNEL_TYPE, OPEN_FAILED_RESOURCE_SHORTAGE,
 )
-
 from paramiko.sftp import (
     SFTP_OK, SFTP_EOF, SFTP_NO_SUCH_FILE, SFTP_PERMISSION_DENIED, SFTP_FAILURE,
     SFTP_BAD_MESSAGE, SFTP_NO_CONNECTION, SFTP_CONNECTION_LOST,
     SFTP_OP_UNSUPPORTED,
 )
+from paramiko._version import __version__, __version_info__  # noqa: F401
 
-from paramiko.common import io_sleep
 
-
-__author__ = "Jeff Forcier <jeff@bitprophet.org>"
+__author__ = "various"
 __license__ = "GNU Lesser General Public License (LGPL)"
+__pkgname__ = "paramiko-ng"
 
 __all__ = [
-    '__version__',
-    '__version_info__',
     'Transport',
     'SSHClient',
     'MissingHostKeyPolicy',

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -34,8 +34,8 @@ from hashlib import sha1, sha256, sha512
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
 
-import paramiko
 from paramiko import util
+from paramiko._version import __version__
 from paramiko.auth_handler import AuthHandler
 from paramiko.ssh_gss import GSSAuth
 from paramiko.channel import Channel
@@ -105,7 +105,7 @@ class Transport(threading.Thread, ClosingContextManager):
     _DECRYPT = object()
 
     _PROTO_ID = '2.0'
-    _CLIENT_ID = 'paramiko_{}'.format(paramiko.__version__)
+    _CLIENT_ID = 'ParamikoNG'
 
     # These tuples of algorithm identifiers are in preference order; do not
     # reorder without reason!
@@ -342,7 +342,9 @@ class Transport(threading.Thread, ClosingContextManager):
 
         # negotiated crypto parameters
         self.packetizer = Packetizer(sock)
-        self.local_version = 'SSH-' + self._PROTO_ID + '-' + self._CLIENT_ID
+        self.local_version = "SSH-%s-%s_%s" % (
+            self._PROTO_ID, self._CLIENT_ID, __version__
+        )
         self.remote_version = ''
         self.local_cipher = self.remote_cipher = ''
         self.local_kex_init = self.remote_kex_init = None


### PR DESCRIPTION
also, probably better not to include `__version__` in `__all__`