### PR TITLE
prefer stdlib unittest.mock over external package

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,4 +5,4 @@ pycodestyle==2.5.0
 pyflakes==2.1.1
 # for running tests
 pytest==4.4.1
-mock==2.0.0
+mock==2.0.0;python_version<"3.3"

--- a/tests/test_channelfile.py
+++ b/tests/test_channelfile.py
@@ -1,4 +1,7 @@
-from mock import patch, create_autospec
+try:
+    from unittest.mock import patch, create_autospec
+except ImportError:
+    from mock import patch, create_autospec
 
 from paramiko import Channel, ChannelFile, ChannelStderrFile, ChannelStdinFile
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -27,7 +27,10 @@ import time
 import threading
 import random
 import unittest
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from paramiko import (
     Transport, SecurityOptions, ServerInterface, RSAKey, SSHException,


### PR DESCRIPTION
Prefer and use built-in unittest.mock in Python 3.3+ instead
of unnecessarily requiring the external mock package.  This helps
distributions that are phasing out Python 2 to remove redundant
packages.

port of https://github.com/paramiko/paramiko/pull/1666