### PR TITLE
channel: check if already closed in _send_eof() 

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -944,6 +944,7 @@ class Channel (ClosingContextManager):
             # feign "read" shutdown
             self.eof_received = 1
         if (how == 1) or (how == 2):
+            m = None
             self.lock.acquire()
             try:
                 m = self._send_eof()
@@ -1230,7 +1231,7 @@ class Channel (ClosingContextManager):
 
     def _send_eof(self):
         # you are holding the lock.
-        if self.eof_sent:
+        if self.eof_sent or self.closed:
             return None
         m = Message()
         m.add_byte(cMSG_CHANNEL_EOF)


### PR DESCRIPTION
fixes paramiko/paramiko#1705
fixes paramiko/paramiko#1584

TODO: confirm with the reproducer script helpfully included in https://github.com/paramiko/paramiko/issues/1705