### PR TITLE
RSA key loading: p and q were swapped

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,17 @@ jobs:
         crypto_ver:
           - "2.4.2"
           - "2.6.1"
-          - "2.8"
+          - "2.9.2"
+          - "3.0"
+        exclude:
+          - imgtag: "python:2.7-buster"
+            crypto_ver: "3.0"
+          - imgtag: "pypy:2.7-7.3"
+            crypto_ver: "3.0"
+          - imgtag: "python:3.4-stretch"
+            crypto_ver: "3.0"
+          - imgtag: "python:3.4-stretch"
+            crypto_ver: "2.9.2"
 
     container: "${{matrix.imgtag}}"
     steps:

--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -185,8 +185,8 @@ class RSAKey(PKey):
             e = msg.get_mpint()
             d = msg.get_mpint()
             iqmp = msg.get_mpint()
-            q = msg.get_mpint()
             p = msg.get_mpint()
+            q = msg.get_mpint()
 
             public_numbers = rsa.RSAPublicNumbers(e=e, n=n)
             key = rsa.RSAPrivateNumbers(


### PR DESCRIPTION
This currently works, because OpenSSL simply re-computes iqmp when
it doesn't match the p & q values. However a future pyca/cryptography
patch enforces this.

port of https://github.com/paramiko/paramiko/pull/1723