### PR TITLE
Use supplied password for authentication even if only keyboard-intera…

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -656,7 +656,10 @@ class SSHClient (ClosingContextManager):
         # possible two_factor second factors
         # (allowed_types could have been updated, only if two_factor)
 
-        if password is not None and 'password' in allowed_types:
+        if password is not None and (
+            'password' in allowed_types or
+            'keyboard-interactive' in allowed_types
+        ):
             try:
                 self._log(DEBUG, 'Trying password')
                 allowed_types = set(


### PR DESCRIPTION
…ctive is supported

If a password is supplied to the client _auth method, use it event if
only the keyboard-interactive auth type is supported. If this fails the
_auth method will fallback to a true keyboard-interactive
authentication.

ploxiln/paramiko-ng#87