### PR TITLE
update Thread method calls deprecated in Python-3.10

### DIFF
--- a/demos/rforward.py
+++ b/demos/rforward.py
@@ -75,7 +75,7 @@ def reverse_forward_tunnel(server_port, remote_host, remote_port, transport):
         if chan is None:
             continue
         thr = threading.Thread(target=handler, args=(chan, remote_host, remote_port))
-        thr.setDaemon(True)
+        thr.daemon = True
         thr.start()
 
 

--- a/paramiko/buffered_pipe.py
+++ b/paramiko/buffered_pipe.py
@@ -107,7 +107,7 @@ class BufferedPipe (object):
             if self._event is not None:
                 self._event.set()
             self._buffer_frombytes(b(data))
-            self._cv.notifyAll()
+            self._cv.notify_all()
         finally:
             self._lock.release()
 
@@ -209,7 +209,7 @@ class BufferedPipe (object):
         self._lock.acquire()
         try:
             self._closed = True
-            self._cv.notifyAll()
+            self._cv.notify_all()
             if self._event is not None:
                 self._event.set()
         finally:

--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -1053,7 +1053,7 @@ class Channel (ClosingContextManager):
             if self.ultra_debug:
                 self._log(DEBUG, 'window up {}'.format(nbytes))
             self.out_window_size += nbytes
-            self.out_buffer_cv.notifyAll()
+            self.out_buffer_cv.notify_all()
         finally:
             self.lock.release()
 
@@ -1222,7 +1222,7 @@ class Channel (ClosingContextManager):
         self.closed = True
         self.in_buffer.close()
         self.in_stderr_buffer.close()
-        self.out_buffer_cv.notifyAll()
+        self.out_buffer_cv.notify_all()
         # Notify any waiters that we are closed
         self.event.set()
         self.status_event.set()

--- a/paramiko/sftp_file.py
+++ b/paramiko/sftp_file.py
@@ -504,7 +504,7 @@ class SFTPFile (BufferedFile):
         self._prefetch_done = False
 
         t = threading.Thread(target=self._prefetch_thread, args=(chunks,))
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
 
     def _prefetch_thread(self, chunks):

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -334,7 +334,7 @@ class Transport(threading.Thread, ClosingContextManager):
 
         # okay, normal socket-ish flow here...
         threading.Thread.__init__(self)
-        self.setDaemon(True)
+        self.daemon = True
         self.sock = sock
         # we set the timeout so we can check self.active periodically to
         # see if we should bail. socket.timeout exception is never propagated.

--- a/paramiko/util.py
+++ b/paramiko/util.py
@@ -210,7 +210,7 @@ _g_thread_lock = threading.Lock()
 
 def get_thread_id():
     global _g_thread_ids, _g_thread_counter, _g_thread_lock
-    tid = id(threading.currentThread())
+    tid = id(threading.current_thread())
     try:
         return _g_thread_ids[tid]
     except KeyError:

--- a/tests/loop.py
+++ b/tests/loop.py
@@ -81,7 +81,7 @@ class LoopSocket (object):
         self.__lock.acquire()
         try:
             self.__in_buffer += data
-            self.__cv.notifyAll()
+            self.__cv.notify_all()
         finally:
             self.__lock.release()
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -720,7 +720,7 @@ class TransportTest(unittest.TestCase):
         class SendThread(threading.Thread):
             def __init__(self, chan, iterations, done_event):
                 threading.Thread.__init__(self, None, None, self.__class__.__name__)
-                self.setDaemon(True)
+                self.daemon = True
                 self.chan = chan
                 self.iterations = iterations
                 self.done_event = done_event
@@ -741,7 +741,7 @@ class TransportTest(unittest.TestCase):
         class ReceiveThread(threading.Thread):
             def __init__(self, chan, done_event):
                 threading.Thread.__init__(self, None, None, self.__class__.__name__)
-                self.setDaemon(True)
+                self.daemon = True
                 self.chan = chan
                 self.done_event = done_event
                 self.watchdog_event = threading.Event()


### PR DESCRIPTION
the new method names were added way back in Python-2.6

port of https://github.com/paramiko/paramiko/pull/1870