### PR TITLE
channel: fix race between sending channel EOF and CLOSE messages

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -948,7 +948,8 @@ class Channel (ClosingContextManager):
             m = None
             self.lock.acquire()
             try:
-                m = self._eof_internal()
+                if self.active:
+                    m = self._eof_internal()
             finally:
                 self.lock.release()
             if m is not None:
@@ -1230,7 +1231,7 @@ class Channel (ClosingContextManager):
 
     def _eof_internal(self):
         # you are holding the lock.
-        if self.eof_sent or self.closed:
+        if self.eof_sent:
             return None
         m = Message()
         m.add_byte(cMSG_CHANNEL_EOF)

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1716,7 +1716,7 @@ class Transport(threading.Thread, ClosingContextManager):
     def _send_message(self, data):
         self.packetizer.send_message(data)
 
-    def _send_user_message(self, data):
+    def _send_user_message(self, data, confirm_callback=None):
         """
         send a message, but block if we're in key negotiation.  this is used
         for user-initiated requests.
@@ -1734,7 +1734,8 @@ class Transport(threading.Thread, ClosingContextManager):
             if time.time() > start + self.clear_to_send_timeout:
                 raise SSHException('Key-exchange timed out waiting for key negotiation')
         try:
-            self._send_message(data)
+            if confirm_callback is None or confirm_callback():
+                self._send_message(data)
         finally:
             self.clear_to_send_lock.release()
 


### PR DESCRIPTION
While the channel tracks its state for generating messages under
its own lock, it needs to release that lock before calling the
transport method to send a message, which uses the transport's lock.
Messages could be generated under the correct conditions and in the
correct order, but then sent in a different order, if two different
threads are calling channel methods.

This was made much more likely by the recent addition of
ChannelStdinFile (in paramiko-ng 2.8.0) which calls shutdown_write()
automatically when closed. So, for now, protect only EOF to fix the
immediate regression, and reduce code churn. There is already a mess
of state checking of dubious robustness, e.g. the open_only()
decorator ...

This problem was well described in paramiko/paramiko#1115 and this
solution is heavily inspired by paramiko/paramiko#1137 so:

Co-Authored-By: Ryan <rrasti@google.com>

----------------

fixes #98 
fixes paramiko/paramiko#1705