### PR TITLE
rsakey: pad received signature with leading zeros

### DIFF
--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -128,10 +128,15 @@ class RSAKey(PKey):
         if isinstance(key, rsa.RSAPrivateKey):
             key = key.public_key()
 
+        # pad received signature with leading zeros, key.verify() expects
+        # a signature of key_size bits (e.g. PuTTY doesn't pad)
+        sign = msg.get_binary()
+        diff = key.key_size - len(sign) * 8
+        if diff > 0:
+            sign = b"\x00" * ((diff + 7) // 8) + sign
+
         try:
-            key.verify(
-                msg.get_binary(), data, padding.PKCS1v15(), hashes.SHA1()
-            )
+            key.verify(sign, data, padding.PKCS1v15(), hashes.SHA1())
         except InvalidSignature:
             return False
         else:


### PR DESCRIPTION
Patch author noticed that paramiko ssh server rejects userauth request when
PuTTY connects with an RSA key, about 1% of the time.

OpenSSH server pads leading zeros to a signature before verifying it.
Putty even has an FAQ about this particular bug, explaining that:

> The SSH-2 specification says that an unpadded signature MUST be accepted

https://github.com/openssh/openssh-portable/blob/V_8_8_P1/ssh-rsa.c#L296-L312
https://documentation.help/PuTTY/config-ssh-bug-sig.html

port of https://github.com/paramiko/paramiko/pull/1933