### PR TITLE
pkey: __eq__() should not use hash()

### DIFF
--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -209,26 +209,20 @@ class PKey(object):
     def __str__(self):
         return self.asbytes()
 
-    # noinspection PyUnresolvedReferences
-    # TODO: The comparison functions should be removed as per:
-    # https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
     def __cmp__(self, other):
+        # python-2 only, same purpose as __eq__()
+        return cmp(self.asbytes(), other.asbytes())  # noqa
+
+    def __eq__(self, other):
         """
-        Compare this key to another.  Returns 0 if this key is equivalent to
-        the given key, or non-0 if they are different.  Only the public parts
+        Compare this key to another.  Returns True if this key is equivalent to
+        the given key, or False if they are different.  Only the public parts
         of the key are compared, so a public key will compare equal to its
         corresponding private key.
 
         :param .PKey other: key to compare to.
         """
-        hs = hash(self)
-        ho = hash(other)
-        if hs != ho:
-            return cmp(hs, ho)   # noqa
-        return cmp(self.asbytes(), other.asbytes())  # noqa
-
-    def __eq__(self, other):
-        return hash(self) == hash(other)
+        return self.asbytes() == other.asbytes()
 
     def get_name(self):
         """

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -612,6 +612,25 @@ class KeyTest(unittest.TestCase):
             _support('test_rsa.key-cert.pub'),
         )
 
+    def keys_loaded_twice(self):
+        for key_class, filename in [
+            (RSAKey, "test_rsa.key"),
+            (DSSKey, "test_dss.key"),
+            (ECDSAKey, "test_ecdsa_256.key"),
+            (Ed25519Key, "test_ed25519.key"),
+        ]:
+            key1 = key_class.from_private_key_file(_support(filename))
+            key2 = key_class.from_private_key_file(_support(filename))
+            yield key1, key2
+
+    def test_keys_are_comparable(self):
+        for key1, key2 in self.keys_loaded_twice():
+            assert key1 == key2
+
+    def test_keys_are_hashable(self):
+        for key1, key2 in self.keys_loaded_twice():
+            assert hash(key1) == hash(key2)
+
     def test_autodetect_ed25519(self):
         key = load_private_key_file(_support("test_ed25519.key"))
         self.assertIsInstance(key, Ed25519Key)


### PR DESCRIPTION
... because `hash()` is too weak and not intended for this.
Also simplify `__cmp__()` (which did work fine).

This fixes a security flaw. If you are using Paramiko with Python 2, or a Python 3 which is running with PYTHONHASHSEED=0, it is possible for an attacker to craft a new keypair from an exfiltrated public key, which Paramiko would consider equal to the original key.

This could enable attacks such as:
 * Paramiko server processes would incorrectly authenticate the attacker (using their generated private key) as if they were the victim.
 * Paramiko client processes would incorrectly validate a connected server (when host key verification is enabled) while subjected to a man-in-the-middle attack. This impacts more users than the server-side version, but also carries higher requirements for the attacker, namely successful DNS poisoning or other MITM techniques.

Reported by @jun66j5 in https://github.com/paramiko/paramiko/issues/908
Vulnerability description by Jeff Forcier <jeff@bitprophet.org>
see also https://www.paramiko.org/changelog.html#2.8.1