### PR TITLE
rsakey,ecdsakey: catch TypeError and UnsupportedAlgorithm

### DIFF
--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -20,7 +20,7 @@
 ECDSA keys
 """
 
-from cryptography.exceptions import InvalidSignature
+from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -277,7 +277,7 @@ class ECDSAKey(PKey):
                 key = serialization.load_der_private_key(
                     data, password=None, backend=default_backend()
                 )
-            except (ValueError, AssertionError) as e:
+            except (ValueError, TypeError, AssertionError, UnsupportedAlgorithm) as e:
                 raise SSHException(str(e))
 
         elif pkformat == self.FORMAT_OPENSSH:

--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -20,7 +20,7 @@
 RSA keys.
 """
 
-from cryptography.exceptions import InvalidSignature
+from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa, padding
@@ -176,7 +176,7 @@ class RSAKey(PKey):
                 key = serialization.load_der_private_key(
                     data, password=None, backend=default_backend()
                 )
-            except ValueError as e:
+            except (ValueError, TypeError, UnsupportedAlgorithm) as e:
                 raise SSHException(str(e))
 
         elif pkformat == self.FORMAT_OPENSSH:


### PR DESCRIPTION
... when using Cryptography to load private key material.
Prior to this change, these exceptions bubble up as-is instead of becoming
SSHException instances like most other key-loading errors.

port of https://github.com/paramiko/paramiko/pull/1266 / https://github.com/paramiko/paramiko/commit/6b1513e79a3244ccd5879fdd3399ea97f87f16f9