### PR TITLE
pkey: shared implementation of __hash__() and __str__()

### DIFF
--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -392,9 +392,6 @@ class AgentKey(PKey):
     def asbytes(self):
         return self.blob
 
-    def __str__(self):
-        return self.asbytes()
-
     def get_name(self):
         return self.name
 

--- a/paramiko/dsskey.py
+++ b/paramiko/dsskey.py
@@ -87,12 +87,6 @@ class DSSKey(PKey):
         m.add_mpint(self.y)
         return m.asbytes()
 
-    def __str__(self):
-        return self.asbytes()
-
-    def __hash__(self):
-        return hash((self.get_name(), self.p, self.q, self.g, self.y))
-
     def get_name(self):
         return 'ssh-dss'
 

--- a/paramiko/dsskey.py
+++ b/paramiko/dsskey.py
@@ -217,8 +217,8 @@ class DSSKey(PKey):
         return key
 
     # ...internals...
-    def _decode_key(self, data):
-        pkformat, data = data
+    def _decode_key(self, _raw):
+        pkformat, data = _raw
         # private key file contains:
         # DSAPrivateKey = { version = 0, p, q, g, y, x }
         if pkformat == self.FORMAT_ORIGINAL:

--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -263,8 +263,8 @@ class ECDSAKey(PKey):
         return ECDSAKey(vals=(private_key, private_key.public_key()))
 
     # ...internals...
-    def _decode_key(self, data):
-        pkformat, data = data
+    def _decode_key(self, _raw):
+        pkformat, data = _raw
         if pkformat == self.FORMAT_ORIGINAL:
             try:
                 key = serialization.load_der_private_key(

--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -175,21 +175,19 @@ class ECDSAKey(PKey):
 
     def asbytes(self):
         key = self.verifying_key
-        m = Message()
-        m.add_string(self.ecdsa_curve.key_format_identifier)
-        m.add_string(self.ecdsa_curve.nist_name)
-
         numbers = key.public_numbers()
-
         key_size_bytes = (key.curve.key_size + 7) // 8
 
         x_bytes = deflate_long(numbers.x, add_sign_padding=False)
         x_bytes = b'\x00' * (key_size_bytes - len(x_bytes)) + x_bytes
-
         y_bytes = deflate_long(numbers.y, add_sign_padding=False)
         y_bytes = b'\x00' * (key_size_bytes - len(y_bytes)) + y_bytes
 
         point_str = four_byte + x_bytes + y_bytes
+
+        m = Message()
+        m.add_string(self.ecdsa_curve.key_format_identifier)
+        m.add_string(self.ecdsa_curve.nist_name)
         m.add_string(point_str)
         return m.asbytes()
 

--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -193,13 +193,6 @@ class ECDSAKey(PKey):
         m.add_string(point_str)
         return m.asbytes()
 
-    def __str__(self):
-        return self.asbytes()
-
-    def __hash__(self):
-        return hash((self.get_name(), self.verifying_key.public_numbers().x,
-                     self.verifying_key.public_numbers().y))
-
     def get_name(self):
         return self.ecdsa_curve.key_format_identifier
 

--- a/paramiko/ed25519key.py
+++ b/paramiko/ed25519key.py
@@ -112,9 +112,6 @@ class Ed25519Key(PKey):
         ))
         return m.asbytes()
 
-    def __hash__(self):
-        return hash((self.get_name(), self.asbytes()))
-
     def get_name(self):
         return "ssh-ed25519"
 

--- a/paramiko/ed25519key.py
+++ b/paramiko/ed25519key.py
@@ -71,45 +71,46 @@ class Ed25519Key(PKey):
             _raw = self._from_private_key_file(filename, password)
         elif file_obj is not None:
             _raw = self._from_private_key(file_obj, password)
-
         if _raw is not None:
-            pkformat, data = _raw
-            if pkformat != self.FORMAT_OPENSSH:
-                raise SSHException("Invalid key format")
-            signing_key = self._parse_signing_key_data(data)
+            signing_key = self._decode_key(_raw)
 
         if signing_key is None and verifying_key is None:
             raise ValueError("need a key")
-        self._signing_key = signing_key
-        self._verifying_key = verifying_key
 
-    def _parse_signing_key_data(self, data):
+        self._signing_key = signing_key
+        self._verifying_key = verifying_key or signing_key.public_key()
+
+    def _decode_key(self, _raw):
+        pkformat, data = _raw
+        if pkformat != self.FORMAT_OPENSSH:
+            raise SSHException("Invalid key format")
+
         message = Message(data)
         public = message.get_binary()
         key_data = message.get_binary()
+        comment = message.get_binary()  # noqa: F841
+
         # The second half of the key data is yet another copy of the public key...
         signing_key = ed25519.Ed25519PrivateKey.from_private_bytes(key_data[:32])
+
         # Verify that all the public keys are the same...
-        if not signing_key.public_key().public_bytes(
+        derived_public = signing_key.public_key().public_bytes(
             serialization.Encoding.Raw,
             serialization.PublicFormat.Raw,
-        ) == public == key_data[32:]:
+        )
+        if public != key_data[32:] or public != derived_public:
             raise SSHException("Invalid key public part mis-match")
-        comment = message.get_binary()  # noqa: F841
+
         return signing_key
 
     def asbytes(self):
-        if self.can_sign():
-            v = self._signing_key.public_key()
-        else:
-            v = self._verifying_key
-
-        m = Message()
-        m.add_string("ssh-ed25519")
-        m.add_string(v.public_bytes(
+        public_bytes = self._verifying_key.public_bytes(
             serialization.Encoding.Raw,
             serialization.PublicFormat.Raw,
-        ))
+        )
+        m = Message()
+        m.add_string("ssh-ed25519")
+        m.add_string(public_bytes)
         return m.asbytes()
 
     def get_name(self):

--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -157,8 +157,8 @@ class RSAKey(PKey):
         return RSAKey(key=key)
 
     # ...internals...
-    def _decode_key(self, data):
-        pkformat, data = data
+    def _decode_key(self, _raw):
+        pkformat, data = _raw
         if pkformat == self.FORMAT_ORIGINAL:
             try:
                 key = serialization.load_der_private_key(

--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -27,7 +27,6 @@ from cryptography.hazmat.primitives.asymmetric import rsa, padding
 
 from paramiko.message import Message
 from paramiko.pkey import PKey, register_pkey_type
-from paramiko.py3compat import PY2
 from paramiko.ssh_exception import SSHException
 
 
@@ -83,22 +82,6 @@ class RSAKey(PKey):
         m.add_mpint(self.public_numbers.e)
         m.add_mpint(self.public_numbers.n)
         return m.asbytes()
-
-    def __str__(self):
-        # NOTE: as per inane commentary in #853, this appears to be the least
-        # crummy way to get a representation that prints identical to Python
-        # 2's previous behavior, on both interpreters.
-        # TODO: replace with a nice clean fingerprint display or something
-        if PY2:
-            # Can't just return the .decode below for Py2 because stuff still
-            # tries stuffing it into ASCII for whatever godforsaken reason
-            return self.asbytes()
-        else:
-            return self.asbytes().decode('utf8', errors='ignore')
-
-    def __hash__(self):
-        return hash((self.get_name(), self.public_numbers.e,
-                     self.public_numbers.n))
 
     def get_name(self):
         return 'ssh-rsa'

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -158,9 +158,6 @@ INVALID/PADDING
 -----END OPENSSH PRIVATE KEY-----
 """
 
-TEST_KEY_BYTESTR_2 = '\x00\x00\x00\x07ssh-rsa\x00\x00\x00\x01#\x00\x00\x00\x81\x00\xd3\x8fV\xea\x07\x85\xa6k%\x8d<\x1f\xbc\x8dT\x98\xa5\x96$\xf3E#\xbe>\xbc\xd2\x93\x93\x87f\xceD\x18\xdb \x0c\xb3\xa1a\x96\xf8e#\xcc\xacS\x8a#\xefVlE\x83\x1epv\xc1o\x17M\xef\xdf\x89DUXL\xa6\x8b\xaa<\x06\x10\xd7\x93w\xec\xaf\xe2\xaf\x95\xd8\xfb\xd9\xbfw\xcb\x9f0)#y{\x10\x90\xaa\x85l\tPru\x8c\t\x19\xce\xa0\xf1\xd2\xdc\x8e/\x8b\xa8f\x9c0\xdey\x84\xd2F\xf7\xcbmm\x1f\x87'  # noqa: E501
-TEST_KEY_BYTESTR_3 = '\x00\x00\x00\x07ssh-rsa\x00\x00\x00\x01#\x00\x00\x00\x00ӏV\x07k%<\x1fT$E#>ғfD\x18 \x0cae#̬S#VlE\x1epvo\x17M߉DUXL<\x06\x10דw\u2bd5ٿw˟0)#y{\x10l\tPru\t\x19Π\u070e/f0yFmm\x1f'  # noqa: E501
-
 
 class KeyTest(unittest.TestCase):
 
@@ -187,6 +184,11 @@ class KeyTest(unittest.TestCase):
 
         assert hexlify(key.get_fingerprint()).decode() == fingerprint_md5.replace(':', '')
         assert key.get_fingerprint_sha256_b64() == fingerprint_sha256
+        if PY2:
+            assert str(key) == key.asbytes()
+        else:
+            assert name in str(key)
+            assert fingerprint_sha256 in str(key)
 
     def test_generate_key_bytes(self):
         x1234 = b'\x01\x02\x03\x04'
@@ -483,11 +485,6 @@ class KeyTest(unittest.TestCase):
             self.assertEqual(key, key2)
         finally:
             os.remove(newfile)
-
-    def test_stringification(self):
-        key = RSAKey.from_private_key_file(_support('test_rsa.key'))
-        comparable = TEST_KEY_BYTESTR_2 if PY2 else TEST_KEY_BYTESTR_3
-        self.assertEqual(str(key), comparable)
 
     @pytest.mark.skipif("not Ed25519Key.is_supported()")
     def test_ed25519(self):


### PR DESCRIPTION
Just use `asbytes()` in `__hash__()` for simplicity.

For python3, `__str__()` would raise exceptions for most
key types, and was uselessly mangled for RSAKey. Make it
return a string with type and fingerprint.
(Keep old behavior for python2: public key bytes.)

fixes https://github.com/paramiko/paramiko/issues/853