### PR TITLE
pkey: fix __str__() for python3 (backport for 2.7)

### DIFF
--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -392,8 +392,8 @@ class AgentKey(PKey):
     def asbytes(self):
         return self.blob
 
-    def __str__(self):
-        return self.asbytes()
+    def __hash__(self):
+        return hash(self.asbytes())
 
     def get_name(self):
         return self.name

--- a/paramiko/dsskey.py
+++ b/paramiko/dsskey.py
@@ -81,9 +81,6 @@ class DSSKey(PKey):
         m.add_mpint(self.y)
         return m.asbytes()
 
-    def __str__(self):
-        return self.asbytes()
-
     def __hash__(self):
         return hash((self.get_name(), self.p, self.q, self.g, self.y))
 

--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -187,9 +187,6 @@ class ECDSAKey(PKey):
         m.add_string(point_str)
         return m.asbytes()
 
-    def __str__(self):
-        return self.asbytes()
-
     def __hash__(self):
         return hash((self.get_name(), self.verifying_key.public_numbers().x,
                      self.verifying_key.public_numbers().y))

--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -23,7 +23,7 @@ Common API for all public keys.
 import base64
 from binascii import unhexlify
 import os
-from hashlib import md5
+from hashlib import md5, sha256
 import re
 
 import bcrypt
@@ -34,7 +34,7 @@ from cryptography.hazmat.primitives.ciphers import algorithms, modes, Cipher
 
 from paramiko import util
 from paramiko.common import o600
-from paramiko.py3compat import u, encodebytes, decodebytes, b, string_types, byte_ord
+from paramiko.py3compat import u, encodebytes, decodebytes, b, string_types, byte_ord, PY2
 from paramiko.ssh_exception import SSHException, PasswordRequiredException
 from paramiko.message import Message
 
@@ -103,14 +103,20 @@ class PKey(object):
 
     def asbytes(self):
         """
-        Return a string of an SSH `.Message` made up of the public part(s) of
+        Return bytes of an SSH `.Message` made up of the public part(s) of
         this key.  This string is suitable for passing to `__init__` to
         re-create the key object later.
         """
-        return bytes()
+        raise NotImplementedError()
 
     def __str__(self):
-        return self.asbytes()
+        if PY2:
+            # strange original behavior for backwards compatibility
+            return self.asbytes()
+        else:
+            fingerprint = sha256(self.asbytes()).digest()
+            fingerprint_b64 = u(base64.b64encode(fingerprint)[:-1])
+            return "%s SHA256:%s" % (self.get_name(), fingerprint_b64)
 
     def __cmp__(self, other):
         # python-2 only, same purpose as __eq__()
@@ -125,7 +131,7 @@ class PKey(object):
 
         :param .PKey other: key to compare to.
         """
-        return self.asbytes() == other.asbytes()
+        return isinstance(other, PKey) and self.asbytes() == other.asbytes()
 
     def get_name(self):
         """
@@ -135,7 +141,7 @@ class PKey(object):
             name of this private key type, in SSH terminology, as a `str` (for
             example, ``"ssh-rsa"``).
         """
-        return ''
+        raise NotImplementedError()
 
     def get_bits(self):
         """

--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -27,7 +27,6 @@ from cryptography.hazmat.primitives.asymmetric import rsa, padding
 
 from paramiko.message import Message
 from paramiko.pkey import PKey
-from paramiko.py3compat import PY2
 from paramiko.ssh_exception import SSHException
 
 
@@ -78,18 +77,6 @@ class RSAKey(PKey):
         m.add_mpint(self.public_numbers.e)
         m.add_mpint(self.public_numbers.n)
         return m.asbytes()
-
-    def __str__(self):
-        # NOTE: as per inane commentary in #853, this appears to be the least
-        # crummy way to get a representation that prints identical to Python
-        # 2's previous behavior, on both interpreters.
-        # TODO: replace with a nice clean fingerprint display or something
-        if PY2:
-            # Can't just return the .decode below for Py2 because stuff still
-            # tries stuffing it into ASCII for whatever godforsaken reason
-            return self.asbytes()
-        else:
-            return self.asbytes().decode('utf8', errors='ignore')
 
     def __hash__(self):
         return hash((self.get_name(), self.public_numbers.e,

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -29,7 +29,7 @@ from hashlib import md5
 import pytest
 
 from paramiko import RSAKey, DSSKey, ECDSAKey, Ed25519Key, Message, util
-from paramiko.py3compat import StringIO, byte_chr, b, PY2
+from paramiko.py3compat import StringIO, byte_chr, b
 
 from .util import _support
 
@@ -115,9 +115,6 @@ L4QLcT5aND0EHZLB2fAUDXiWIb2j4rg1mwPlBMiBXA==
 """
 
 x1234 = b'\x01\x02\x03\x04'
-
-TEST_KEY_BYTESTR_2 = '\x00\x00\x00\x07ssh-rsa\x00\x00\x00\x01#\x00\x00\x00\x81\x00\xd3\x8fV\xea\x07\x85\xa6k%\x8d<\x1f\xbc\x8dT\x98\xa5\x96$\xf3E#\xbe>\xbc\xd2\x93\x93\x87f\xceD\x18\xdb \x0c\xb3\xa1a\x96\xf8e#\xcc\xacS\x8a#\xefVlE\x83\x1epv\xc1o\x17M\xef\xdf\x89DUXL\xa6\x8b\xaa<\x06\x10\xd7\x93w\xec\xaf\xe2\xaf\x95\xd8\xfb\xd9\xbfw\xcb\x9f0)#y{\x10\x90\xaa\x85l\tPru\x8c\t\x19\xce\xa0\xf1\xd2\xdc\x8e/\x8b\xa8f\x9c0\xdey\x84\xd2F\xf7\xcbmm\x1f\x87'  # noqa: E501
-TEST_KEY_BYTESTR_3 = '\x00\x00\x00\x07ssh-rsa\x00\x00\x00\x01#\x00\x00\x00\x00ӏV\x07k%<\x1fT$E#>ғfD\x18 \x0cae#̬S#VlE\x1epvo\x17M߉DUXL<\x06\x10דw\u2bd5ٿw˟0)#y{\x10l\tPru\t\x19Π\u070e/f0yFmm\x1f'  # noqa: E501
 
 
 class KeyTest(unittest.TestCase):
@@ -491,11 +488,6 @@ class KeyTest(unittest.TestCase):
             self.assertEqual(key, key2)
         finally:
             os.remove(newfile)
-
-    def test_stringification(self):
-        key = RSAKey.from_private_key_file(_support('test_rsa.key'))
-        comparable = TEST_KEY_BYTESTR_2 if PY2 else TEST_KEY_BYTESTR_3
-        self.assertEqual(str(key), comparable)
 
     @pytest.mark.skipif("not Ed25519Key.is_supported()")
     def test_ed25519(self):


### PR DESCRIPTION
For python3, `__str__()` would raise exceptions for most
key types, and was uselessly mangled for RSAKey. Make it
return a string with type and fingerprint.
(Keep old behavior for python2: public key bytes.)

Also give AgentKey a `__hash__()` implementation.

fixes https://github.com/paramiko/paramiko/issues/853

partial backport of 30a09ce6dd9b from ploxiln/paramiko-ng#114
(but need to inline sha256-base64 fingerprint style)