### PR TITLE
docs: cleanup method pydocs a bit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Paramiko-NG
 This is a fork of `paramiko <https://github.com/paramiko/paramiko/>`_ for more active maintenance.
 
 This is still imported under the name ``paramiko``, but you can
-install with the package name *paramiko-ng* (default) or *paramiko*
+install with the pip-package-name *paramiko-ng* (default) or *paramiko*
 (by setting the environment variable ``PARAMIKO_REPLACE``, see `Installation`_).
 
 Changelog: `releases <https://github.com/ploxiln/paramiko-ng/releases>`_
@@ -13,7 +13,7 @@ Changelog: `releases <https://github.com/ploxiln/paramiko-ng/releases>`_
 :Paramiko-NG: Python SSH module
 :Copyright:   Copyright (c) 2003-2009  Robey Pointer <robeypointer@gmail.com>
 :Copyright:   Copyright (c) 2013-2019  Jeff Forcier <jeff@bitprophet.org>
-:Copyright:   Copyright (c) 2019-2020  Pierce Lopez <pierce.lopez@gmail.com>
+:Copyright:   Copyright (c) 2019-2022  Pierce Lopez <pierce.lopez@gmail.com>
 :License:     `LGPL <https://www.gnu.org/copyleft/lesser.html>`_
 :API docs:    https://ploxiln.github.io/paramiko-ng/
 :Development: https://github.com/ploxiln/paramiko-ng/
@@ -42,15 +42,16 @@ Installation
 The import name is still just ``paramiko``. Make sure the original *paramiko*
 is not installed before installing *paramiko-ng* - otherwise pip may report
 success even though *paramiko-ng* was not correctly installed.
+(Because the import name is the same, installed files can conflict.)
 
 The most common way to install is simply::
 
     pip install paramiko-ng
 
 You can also install under the original "paramiko" pip-package-name, in order to
-satisfy requirements for other packages (replace "2.7.6" with desired version)::
+satisfy requirements for other packages (replace "2.8.10" with desired version)::
 
-    PARAMIKO_REPLACE=1 pip install https://github.com/ploxiln/paramiko-ng/archive/2.7.6.tar.gz#egg=paramiko
+    PARAMIKO_REPLACE=1 pip install "https://github.com/ploxiln/paramiko-ng/archive/2.8.10.tar.gz#egg=paramiko"
 
 For dependencies and other details, see https://ploxiln.github.io/paramiko-ng/installing.html
 
@@ -91,7 +92,7 @@ This prints out the results of executing ``ls`` on a remote server. The host
 key ``b'AAA...'`` should of course be replaced by the actual base64 encoding of the
 host key.  If you skip host key verification, the connection is not secure!
 
-The following example scripts (in demos/) get progressively more detailed:
+The following example scripts (in `demos/ <demos/>`_) get progressively more detailed:
 
 :demo_simple.py:
     Calls invoke_shell() and emulates a terminal/TTY through which you can
@@ -123,18 +124,18 @@ Use
 
 The demo scripts are probably the best example of how to use this package.
 
-A much easier alternative to using paramiko directly is to use `Fabric <https://www.fabfile.org/>`_
-(or, for managed networking equipment, `netmiko <http://ktbyers.github.io/netmiko/>`_).
-To use *paramiko-ng* with these packages, currently, you need to install paramiko-ng
-with the pip-package-name *paramiko*, using the ``PARAMIKO_REPLACE`` environment varariable
-as described in `Installation`_.
+A much easier alternative to using paramiko-ng directly is to use
+`fab-classic <https://github.com/ploxiln/fab-classic/#readme>`_ or
+`Fabric <https://www.fabfile.org/>`_ 2.x (or, for managed networking equipment,
+`netmiko <http://ktbyers.github.io/netmiko/>`_). Whereas recent releases of
+*fab-classic* depend on *paramiko-ng* directly, to use this with *Fabric* or
+*netmiko* you need to install *paramiko-ng* with the pip-package-name
+"paramiko", using the ``PARAMIKO_REPLACE`` environment variable as described
+above in `Installation`_.
 
-There is also `fab-classic <https://github.com/ploxiln/fab-classic/#readme>`_, a fork of Fabric-1.x
-which works a bit differently than current Fabric-2.x. The latest release of fab-classic depends
-on paramiko-ng directly.
 
 There are also unit tests which will verify that most of the components are working correctly::
 
     $ pip install -r dev-requirements.txt
-    $ pytest
+    $ pytest -v
 

--- a/paramiko/ber.py
+++ b/paramiko/ber.py
@@ -26,10 +26,6 @@ class BERException (Exception):
 
 
 class BER(object):
-    """
-    Robey's tiny little attempt at a BER decoder.
-    """
-
     def __init__(self, content=bytes()):
         self.content = b(content)
         self.idx = 0

--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -133,9 +133,6 @@ class Channel (ClosingContextManager):
             pass
 
     def __repr__(self):
-        """
-        Return a string representation of this object, for debugging.
-        """
         out = '<paramiko.Channel {}'.format(self.chanid)
         if self.closed:
             out += ' (closed)'
@@ -1384,9 +1381,6 @@ class ChannelFile (BufferedFile):
         self._set_mode(mode, bufsize)
 
     def __repr__(self):
-        """
-        Returns a string representation of this object, for debugging.
-        """
         return '<paramiko.ChannelFile from ' + repr(self.channel) + '>'
 
     def _read(self, size):

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -62,9 +62,6 @@ class SSHClient (ClosingContextManager):
     """
 
     def __init__(self):
-        """
-        Create a new SSHClient.
-        """
         self._system_host_keys = HostKeys()
         self._host_keys = HostKeys()
         self._host_keys_filename = None
@@ -246,55 +243,53 @@ class SSHClient (ClosingContextManager):
         :param str hostname: the server to connect to
         :param int port: the server port to connect to
         :param str username:
-            the username to authenticate as (defaults to the current local
-            username)
+            the username to authenticate as (defaults to the current local username)
         :param str password:
             Used for password authentication; is also used for private key
             decryption if ``passphrase`` is not given.
         :param str passphrase:
-            Used for decrypting private keys.
-        :param .PKey pkey: an optional private key to use for authentication
+            Used for decrypting private key files
+        :param .PKey pkey:
+            an optional private key (object) to use for authentication
         :param str key_filename:
             the filename, or list of filenames, of optional private key(s)
             and/or certs to try for authentication
         :param bool look_for_keys:
-            set to False to disable searching for discoverable private key
-            files in ``~/.ssh/``
+            set to False to disable searching for discoverable private key files in ``~/.ssh/``
         :param bool allow_agent:
             set to False to disable connecting to the SSH agent
         :param float timeout:
             an optional timeout (in seconds) for the overall SSH session
             negotiation (also applies to the TCP connection)
-        :param float banner_timeout: an optional timeout (in seconds) to wait
-            for the SSH banner to be presented.
-        :param float handshake_timeout: an optional timeout (in seconds) to wait
-            for the SSH handshake to finish after SSH banner exchange.
-        :param float auth_timeout: an optional timeout (in seconds) to wait for
-            an authentication response.
-        :param bool compress: set to True to turn on compression
+        :param float banner_timeout:
+            override default timeout (in seconds) to wait for the SSH banner
+            to be presented
+        :param float handshake_timeout:
+            override default timeout (in seconds) to wait for the SSH handshake
+            to finish after SSH banner exchange
+        :param float auth_timeout:
+            override default timeout (in seconds) to wait for an authentication response
+        :param bool compress:
+            enable deflate/gzip SSH transport compression
         :param socket sock:
             an open socket or socket-like object (such as a `.Channel`) to use
             for communication to the target host
         :param bool gss_auth:
-            ``True`` if you want to use GSS-API authentication
+            Use GSS-API authentication
         :param bool gss_kex:
             Perform GSS-API Key Exchange and user authentication
-        :param bool gss_deleg_creds: Delegate GSS-API client credentials or not
+        :param bool gss_deleg_creds:
+            Whether to delegate GSS-API client credentials (default ``True``)
         :param str gss_host:
             The targets name in the kerberos database. default: hostname
         :param bool gss_trust_dns:
             Indicates whether or not the DNS is trusted to securely
-            canonicalize the name of the host being connected to (default
-            ``True``).
+            canonicalize the name of the host being connected to (default ``True``)
 
-        :raises:
-            `.BadHostKeyException` -- if the server's host key could not be
-            verified
+        :raises: `.BadHostKeyException` -- if the server's host key could not be verified
         :raises: `.AuthenticationException` -- if authentication failed
-        :raises:
-            `.SSHException` -- if there was any other error connecting or
-            establishing an SSH session
-        :raises socket.error: if a socket error occurred while connecting
+        :raises: `.SSHException` -- if there was some other error establishing an SSH session
+        :raises: `socket.error` -- if a socket error occurred while connecting
 
         .. versionchanged:: 1.15
             Added the ``banner_timeout``, ``gss_auth``, ``gss_kex``,

--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -45,9 +45,6 @@ class SSHConfig (object):
     SETTINGS_REGEX = re.compile(r'(\w+)(?:\s*=\s*|\s+)(.+)')
 
     def __init__(self):
-        """
-        Create a new OpenSSH config object.
-        """
         self._config = []
 
     def parse(self, file_obj):

--- a/paramiko/dsskey.py
+++ b/paramiko/dsskey.py
@@ -39,8 +39,7 @@ from paramiko.pkey import PKey, register_pkey_type
 @register_pkey_type
 class DSSKey(PKey):
     """
-    Representation of a DSS key which can be used to sign an verify SSH2
-    data.
+    Representation of a DSS key which can be used to sign and verify SSH2 data.
     """
 
     LEGACY_TYPE = "DSA"

--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -92,8 +92,7 @@ class _ECDSACurveSet(object):
 @register_pkey_type
 class ECDSAKey(PKey):
     """
-    Representation of an ECDSA key which can be used to sign and verify SSH2
-    data.
+    Representation of an ECDSA key which can be used to sign and verify SSH2 data.
     """
 
     LEGACY_TYPE = "EC"

--- a/paramiko/message.py
+++ b/paramiko/message.py
@@ -53,15 +53,10 @@ class Message (object):
             self.packet = BytesIO()
 
     def __str__(self):
-        """
-        Return the byte stream content of this message, as a string/bytes obj.
-        """
+        # TODO: should be str, not bytes
         return self.asbytes()
 
     def __repr__(self):
-        """
-        Returns a string representation of this object, for debugging.
-        """
         return 'paramiko.Message(' + repr(self.packet.getvalue()) + ')'
 
     def asbytes(self):

--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -140,7 +140,7 @@ def _unpad(data):
 
 class PKey(object):
     """
-    Base class for public keys.
+    Base class for keys.
     """
 
     # known encryption types for private key files:
@@ -183,17 +183,18 @@ class PKey(object):
     #: Examples: ``"ssh-rsa"``, ``"ecdsa-sha2-"``
     OPENSSH_TYPE_PREFIX = None
 
-    def __init__(self, msg=None, data=None):
+    def __init__(self, msg=None, data=None, filename=None, password=None):
         """
-        Create a new instance of this public key type.  If ``msg`` is given,
-        the key's public part(s) will be filled in from the message.  If
-        ``data`` is given, the key's public part(s) will be filled in from
-        the string.
+        Create a new instance of this key type.
 
         :param .Message msg:
             an optional SSH `.Message` containing a public key of this type.
-        :param str data: an optional string containing a public key
-            of this type
+        :param bytes data:
+            an optional bytestring containing a public key of this type
+        :param str filename:
+            an optional private key filename to load
+        :param str password:
+            an optional passphrase for decrypting the private key file
 
         :raises: `.SSHException` --
             if a key cannot be created from the ``data`` or ``msg`` given, or
@@ -204,8 +205,8 @@ class PKey(object):
     def asbytes(self):
         """
         Return bytes of an SSH `.Message` made up of the public part(s) of
-        this key.  This string is suitable for passing to `__init__` to
-        re-create the key object later.
+        this key.  This bytestring is suitable for passing to the constructor
+        to re-create the public key object later.
         """
         raise NotImplementedError()
 
@@ -712,8 +713,7 @@ class PublicBlob(object):
 
     .. note::
         Most of the time you'll want to call `from_file`, `from_string` or
-        `from_message` for useful instantiation, the main constructor is
-        basically "I should be using ``attrs`` for this."
+        `from_message` for useful instantiation.
     """
     def __init__(self, type_, blob, comment=None):
         """

--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -33,8 +33,7 @@ from paramiko.ssh_exception import SSHException
 @register_pkey_type
 class RSAKey(PKey):
     """
-    Representation of an RSA key which can be used to sign and verify SSH2
-    data.
+    Representation of an RSA key which can be used to sign and verify SSH2 data.
     """
 
     LEGACY_TYPE = "RSA"

--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -60,8 +60,7 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
     Use `.Transport.set_subsystem_handler` to activate this class.
     """
 
-    def __init__(self, channel, name, server, sftp_si=SFTPServerInterface,
-                 *largs, **kwargs):
+    def __init__(self, channel, name, server, sftp_si=SFTPServerInterface, *largs, **kwargs):
         """
         The constructor for SFTPServer is meant to be called from within the
         `.Transport` as a subsystem handler.  ``server`` and any additional
@@ -73,8 +72,7 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
         :param .ServerInterface server:
             the server object associated with this channel and subsystem
         :param sftp_si:
-            a subclass of `.SFTPServerInterface` to use for handling individual
-            requests.
+            a subclass of `.SFTPServerInterface` to use for handling individual requests
         """
         BaseSFTP.__init__(self)
         SubsystemHandler.__init__(self, channel, name, server)

--- a/paramiko/ssh_gss.py
+++ b/paramiko/ssh_gss.py
@@ -111,10 +111,8 @@ class _SSH_GSSAuth(object):
         self._username = None
         self._session_id = None
         self._service = "ssh-connection"
-        """
-        OpenSSH supports Kerberos V5 mechanism only for GSS-API authentication,
-        so we also support the krb5 mechanism only.
-        """
+        # OpenSSH supports Kerberos V5 mechanism only for GSS-API authentication,
+        # so we also support the krb5 mechanism only.
         self._krb5_mech = "1.2.840.113554.1.2.2"
 
         # client mode

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -96,8 +96,7 @@ class Transport(threading.Thread, ClosingContextManager):
     An SSH Transport attaches to a stream (usually a socket), negotiates an
     encrypted session, authenticates, and then creates stream tunnels, called
     `channels <.Channel>`, across the session.  Multiple channels can be
-    multiplexed across a single session (and often are, in the case of port
-    forwardings).
+    multiplexed across a single session (and often are).
 
     Instances of this class may be used as context managers.
     """
@@ -272,12 +271,11 @@ class Transport(threading.Thread, ClosingContextManager):
         If the object is not actually a socket, it must have the following
         methods:
 
-        - ``send(str)``: Writes from 1 to ``len(str)`` bytes, and returns an
-          int representing the number of bytes written.  Returns
-          0 or raises ``EOFError`` if the stream has been closed.
-        - ``recv(int)``: Reads from 1 to ``int`` bytes and returns them as a
-          string.  Returns 0 or raises ``EOFError`` if the stream has been
-          closed.
+        - ``send(str)``: Writes up to ``len(str)`` bytes, and returns the number
+          of bytes written. Returns 0 or raises ``EOFError`` if the stream has
+          been closed.
+        - ``recv(int)``: Reads up to ``int`` bytes and returns them. Returns an
+          empty bytestring or raises ``EOFError`` if the stream has been closed.
         - ``close()``: Closes the socket.
         - ``settimeout(n)``: Sets a (float) timeout on I/O operations.
 
@@ -289,10 +287,8 @@ class Transport(threading.Thread, ClosingContextManager):
         be used. For more control, pass a connected socket instead.
 
         .. note::
-            Modifying the the window and packet sizes might have adverse
-            effects on your channels created from this transport. The default
-            values are the same as in the OpenSSH code base and have been
-            battle tested.
+            Modifying the window and packet sizes might have adverse
+            effects on your channels created from this transport.
 
         :param socket sock:
             a socket or socket-like object to create the session over.
@@ -748,12 +744,10 @@ class Transport(threading.Thread, ClosingContextManager):
     ):
         """
         Request a new channel to the server, of type ``"session"``.  This is
-        just an alias for calling `open_channel` with an argument of
-        ``"session"``.
+        just an alias for calling `open_channel` with an argument of ``"session"``.
 
         .. note:: Modifying the the window and packet sizes might have adverse
-            effects on the session created. The default values are the same
-            as in the OpenSSH code base and have been battle tested.
+            effects on the session created.
 
         :param int window_size:
             optional window size for this session.
@@ -766,7 +760,7 @@ class Transport(threading.Thread, ClosingContextManager):
             `.SSHException` -- if the request is rejected or the session ends
             prematurely
 
-        .. versionchanged:: 1.13.4/1.14.3/1.15.3
+        .. versionchanged:: 1.15.3
             Added the ``timeout`` argument.
         .. versionchanged:: 1.15
             Added the ``window_size`` and ``max_packet_size`` arguments.
@@ -832,8 +826,7 @@ class Transport(threading.Thread, ClosingContextManager):
         (using `connect` or `start_client`) and authenticating.
 
         .. note:: Modifying the the window and packet sizes might have adverse
-            effects on the channel created. The default values are the same
-            as in the OpenSSH code base and have been battle tested.
+            effects on the channel created.
 
         :param str kind:
             the kind of channel requested (usually ``"session"``,

--- a/setup.py
+++ b/setup.py
@@ -36,19 +36,18 @@ Required packages:
 The import name is still just ``paramiko``. Make sure the original *paramiko*
 is not installed before installing *paramiko-ng* - otherwise pip may report
 success even though *paramiko-ng* was not correctly installed.
-
-To install the development version::
-
-    pip install -e git+https://github.com/ploxiln/paramiko-ng/#egg=paramiko-ng
+(Because the import name is the same, installed files can conflict.)
 
 You can also install under the original "paramiko" pip-package-name,
 in order to satisfy requirements for other packages::
 
-    PARAMIKO_REPLACE=1 pip install https://github.com/ploxiln/paramiko-ng/archive/2.7.4.tar.gz#egg=paramiko
+    PARAMIKO_REPLACE=1 pip install "https://github.com/ploxiln/paramiko-ng/archive/2.8.10.tar.gz#egg=paramiko"
 
-Replace "2.7.4" with the desired recent version, or for latest development version do::
+Replace "2.8.10" with the desired version.
 
-    PARAMIKO_REPLACE=1 pip install git+https://github.com/ploxiln/paramiko-ng/#egg=paramiko
+To install the latest development version::
+
+    pip install -e "git+https://github.com/ploxiln/paramiko-ng/#egg=paramiko-ng"
 
 '''  # noqa: E501
 

--- a/sites/docs/conf.py
+++ b/sites/docs/conf.py
@@ -40,7 +40,7 @@ default_role = 'obj'
 # Autodoc settings
 autodoc_default_options = {
     'members': True,
-    'special-members': True,
+    'special-members': "__init__, __eq__",
 }
 
 # Intersphinx connection to stdlib

--- a/sites/docs/installing.rst
+++ b/sites/docs/installing.rst
@@ -5,15 +5,15 @@ Installing
 Paramiko-NG itself
 ==================
 
-The recommended way to get Paramiko is to **install the latest stable release**
+The recommended way to get Paramiko-NG is to install the latest stable release
 via `pip <http://pip-installer.org>`_::
 
     $ pip install paramiko-ng
 
 You can also install under the original "paramiko" pip-package-name,
-in order to satisfy requirements for other packages (replace "2.7.6" with desired version)::
+in order to satisfy requirements for other packages (replace "2.8.10" with desired version)::
 
-    $ PARAMIKO_REPLACE=1 pip install https://github.com/ploxiln/paramiko-ng/archive/2.7.6.tar.gz#egg=paramiko
+    $ PARAMIKO_REPLACE=1 pip install "https://github.com/ploxiln/paramiko-ng/archive/2.8.10.tar.gz#egg=paramiko"
 
 Paramiko-NG currently supports Python 2.7, 3.4+, and PyPy.
 


### PR DESCRIPTION
~in progress~ done ... ~need to move some `__init__()` docs to the class itself, and mention pkey comparison there too~ nope, backed this out, was too much churn, plenty of easier bits to clean up