### PR TITLE
SSHClient: add get_security_options()

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -447,10 +447,9 @@ class Transport(threading.Thread, ClosingContextManager):
 
     def get_security_options(self):
         """
-        Return a `.SecurityOptions` object which can be used to tweak the
-        encryption algorithms this transport will permit (for encryption,
-        digest/hash operations, public keys, and key exchanges) and the order
-        of preference for them.
+        Return a `.SecurityOptions` object which can be used to tweak the authentication
+        and encryption algorithms this transport will permit (for encryption, digest/hash
+        operations, public keys, and key exchanges) and the order of preference for them.
         """
         return SecurityOptions(self)
 


### PR DESCRIPTION
Re-uses the transport SecurityOptions directly ... but needs to
create a "shadow transport" just for the options, because SSHClient
always creates the Transport (and obtains the socket needed to
create the Transport) in SSHClient.connect() - it can copy from
the "dummy transport" SecurityOptions between creating and using
the real Transport.