### PR TITLE
pkey: fix comparison with None for python2

### DIFF
--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -218,7 +218,8 @@ class PKey(object):
 
     def __cmp__(self, other):
         # python-2 only, same purpose as __eq__()
-        return cmp(self.asbytes(), other.asbytes())  # noqa
+        other_asbytes = other.asbytes() if isinstance(other, PKey) else b""
+        return cmp(self.asbytes(), other_asbytes)  # noqa
 
     def __eq__(self, other):
         """

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -190,6 +190,9 @@ class KeyTest(unittest.TestCase):
             assert name in str(key)
             assert fingerprint_sha256 in str(key)
 
+        # ensure comparison does not raise exception
+        assert key != None  # noqa: E711
+
     def test_generate_key_bytes(self):
         x1234 = b'\x01\x02\x03\x04'
         key = util.generate_key_bytes(md5, x1234, 'happy birthday', 30)


### PR DESCRIPTION
A bug introduced by #106 (79da092beb51) and fixed for python3 in #114 (30a09ce6dd9b).

This bug is hit by `SSHClient.connect()` if the key in known_hosts is a type that the remote does not offer ... and possibly other cases. (It would raise the wrong exception.)

Reported upstream (in _slightly_ different situation) in https://github.com/paramiko/paramiko/pull/1964