### PR TITLE
pkey: fix comparison with None for python2 (2.8 branch)

### DIFF
--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -217,7 +217,8 @@ class PKey(object):
 
     def __cmp__(self, other):
         # python-2 only, same purpose as __eq__()
-        return cmp(self.asbytes(), other.asbytes())  # noqa
+        other_asbytes = other.asbytes() if isinstance(other, PKey) else b""
+        return cmp(self.asbytes(), other_asbytes)  # noqa
 
     def __eq__(self, other):
         """

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -183,6 +183,9 @@ class KeyTest(unittest.TestCase):
         key2 = RSAKey.from_private_key(s)
         self.assertEqual(key, key2)
 
+        # ensure comparison does not raise exception
+        assert key != None  # noqa: E711
+
     def test_load_rsa_password(self):
         key = RSAKey.from_private_key_file(_support('test_rsa_password.key'), 'television')
         self.assertEqual('ssh-rsa', key.get_name())
@@ -207,6 +210,9 @@ class KeyTest(unittest.TestCase):
         s.seek(0)
         key2 = DSSKey.from_private_key(s)
         self.assertEqual(key, key2)
+
+        # ensure comparison does not raise exception
+        assert key != None  # noqa: E711
 
     def test_load_dss_password(self):
         key = DSSKey.from_private_key_file(_support('test_dss_password.key'), 'television')
@@ -319,6 +325,9 @@ class KeyTest(unittest.TestCase):
         s.seek(0)
         key2 = ECDSAKey.from_private_key(s)
         self.assertEqual(key, key2)
+
+        # ensure comparison does not raise exception
+        assert key != None  # noqa: E711
 
     def test_load_ecdsa_password_256(self):
         key = ECDSAKey.from_private_key_file(_support('test_ecdsa_password_256.key'),
@@ -521,6 +530,9 @@ class KeyTest(unittest.TestCase):
             _support('test_ed25519_password.key'), b'abc123'
         )
         self.assertNotEqual(key1.asbytes(), key2.asbytes())
+
+        # ensure comparison does not raise exception
+        assert key1 != None  # noqa: E711
 
     @pytest.mark.skipif("not Ed25519Key.is_supported()")
     def test_ed25519_nopad(self):


### PR DESCRIPTION
A bug introduced by 40daf204b339 (added in v2.8.8) and fixed for python3 in ca3839ebc86c (not yet released on the 2.8 branch).

This bug is hit by SSHClient.connect() if the key in known_hosts is a type that the remote does not offer ... and possibly other cases. (It would raise the wrong exception.)

Reported upstream (in slightly different situation) in https://github.com/paramiko/paramiko/pull/1964

backport of #124