### PR TITLE
util: store thread assigned id in thread-local storage

### DIFF
--- a/paramiko/util.py
+++ b/paramiko/util.py
@@ -205,24 +205,20 @@ def mod_inverse(x, m):
     return u2
 
 
-_g_thread_ids = {}
+_g_thread_data = threading.local()
 _g_thread_counter = 0
 _g_thread_lock = threading.Lock()
 
 
 def get_thread_id():
-    global _g_thread_ids, _g_thread_counter, _g_thread_lock
-    tid = id(threading.current_thread())
+    global _g_thread_data, _g_thread_counter, _g_thread_lock
     try:
-        return _g_thread_ids[tid]
-    except KeyError:
-        _g_thread_lock.acquire()
-        try:
+        return _g_thread_data.id
+    except AttributeError:
+        with _g_thread_lock:
             _g_thread_counter += 1
-            ret = _g_thread_ids[tid] = _g_thread_counter
-        finally:
-            _g_thread_lock.release()
-        return ret
+            _g_thread_data.id = _g_thread_counter
+        return _g_thread_data.id
 
 
 def log_to_file(filename, level=DEBUG):


### PR DESCRIPTION
Avoid leaking memory by only ever adding to the thread IDs dict

fixes paramiko/paramiko#2002
port of https://github.com/paramiko/paramiko/pull/2003