### PR TITLE
agent: support OpenSSH agent on Windows

### DIFF
--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -224,15 +224,20 @@ class AgentClientProxy(object):
             except:
                 # probably a dangling env var: the ssh agent is gone
                 return
+
         elif sys.platform == 'win32':
-            import paramiko.win_pageant as win_pageant
+            from paramiko import win_pageant, win_openssh
             if win_pageant.can_talk_to_agent():
                 conn = win_pageant.PageantConnection()
             else:
-                return
+                if win_openssh.can_talk_to_agent():
+                    conn = win_openssh.OpenSSHAgentConnection()
+                else:
+                    return
         else:
             # no agent support
             return
+
         self._conn = conn
 
     def close(self):
@@ -358,15 +363,20 @@ class Agent(AgentSSH):
             except:
                 # probably a dangling env var: the ssh agent is gone
                 return
+
         elif sys.platform == 'win32':
-            from . import win_pageant
+            from paramiko import win_pageant, win_openssh
             if win_pageant.can_talk_to_agent():
                 conn = win_pageant.PageantConnection()
             else:
-                return
+                if win_openssh.can_talk_to_agent():
+                    conn = win_openssh.OpenSSHAgentConnection()
+                else:
+                    return
         else:
             # no agent support
             return
+
         self._connect(conn)
 
     def close(self):

--- a/paramiko/win_openssh.py
+++ b/paramiko/win_openssh.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2021 Lew Gordon <lew.gordon@genesys.com>
+# Copyright (C) 2022 Patrick Spendrin <ps_ml@gmx.de>
+#
+# This file is part of paramiko.
+#
+# Paramiko is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# Paramiko is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Paramiko; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+import os.path
+
+PIPE_NAME = r"\\.\pipe\openssh-ssh-agent"
+
+
+def can_talk_to_agent():
+    return os.path.exists(PIPE_NAME)
+
+
+class OpenSSHAgentConnection:
+    def __init__(self):
+        self._pipe = open(PIPE_NAME, "rb+", buffering=0)
+
+    def send(self, data):
+        return self._pipe.write(data)
+
+    def recv(self, n):
+        return self._pipe.read(n)
+
+    def close(self):
+        return self._pipe.close()


### PR DESCRIPTION
In addition to Putty's "Pageant" agent, there is now a native openssh
port for windows. If the Putty pageant is not present, try to use the
native port's agent instead.

port of https://github.com/paramiko/paramiko/pull/1868