### PR TITLE
Remove blowfish from transport ciphers

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -172,12 +172,6 @@ class Transport(threading.Thread, ClosingContextManager):
             'block-size': 16,
             'key-size': 32
         },
-        'blowfish-cbc': {
-            'class': algorithms.Blowfish,
-            'mode': modes.CBC,
-            'block-size': 8,
-            'key-size': 16
-        },
         'aes128-cbc': {
             'class': algorithms.AES,
             'mode': modes.CBC,

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -169,9 +169,9 @@ class TransportTest(unittest.TestCase):
     def test_security_options(self):
         o = self.tc.get_security_options()
         self.assertEqual(type(o), SecurityOptions)
-        self.assertTrue(('aes256-cbc', 'blowfish-cbc') != o.ciphers)
-        o.ciphers = ('aes256-cbc', 'blowfish-cbc')
-        self.assertEqual(('aes256-cbc', 'blowfish-cbc'), o.ciphers)
+        self.assertTrue(('aes256-cbc', 'aes192-cbc') != o.ciphers)
+        o.ciphers = ('aes256-cbc', 'aes192-cbc')
+        self.assertEqual(('aes256-cbc', 'aes192-cbc'), o.ciphers)
         try:
             o.ciphers = ('aes256-cbc', 'made-up-cipher')
             self.assertTrue(False)


### PR DESCRIPTION
Backport https://github.com/paramiko/paramiko/pull/2039

Fixes #135.