### PR TITLE
agent: win_openssh: use appropriate syscalls

### DIFF
--- a/paramiko/win_openssh.py
+++ b/paramiko/win_openssh.py
@@ -17,23 +17,39 @@
 # along with Paramiko; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
 import os.path
+import time
 
 PIPE_NAME = r"\\.\pipe\openssh-ssh-agent"
 
 
 def can_talk_to_agent():
-    return os.path.exists(PIPE_NAME)
+    # use os.listdir() instead of os.path.exists(), because os.path.exists()
+    # uses CreateFileW() API and the pipe cannot be reopen unless the server
+    # calls DisconnectNamedPipe().
+    dir_, name = os.path.split(PIPE_NAME)
+    name = name.lower()
+    return any(name == n.lower() for n in os.listdir(dir_))
 
 
 class OpenSSHAgentConnection:
     def __init__(self):
-        self._pipe = open(PIPE_NAME, "rb+", buffering=0)
+        while True:
+            try:
+                self._pipe = os.open(PIPE_NAME, os.O_RDWR | os.O_BINARY)
+            except OSError as e:
+                # retry when errno 22 which means that the server has not
+                # called DisconnectNamedPipe() yet.
+                if e.errno != 22:
+                    raise
+            else:
+                break
+            time.sleep(0.1)
 
     def send(self, data):
-        return self._pipe.write(data)
+        return os.write(self._pipe, data)
 
     def recv(self, n):
-        return self._pipe.read(n)
+        return os.read(self._pipe, n)
 
     def close(self):
-        return self._pipe.close()
+        return os.close(self._pipe)


### PR DESCRIPTION
 * use os.listdir() instead of os.path.exists(), because on windows the
   latter uses CreateFileW() and the pipe cannot be reopened unless the
   server calls DisconnectNamedPipe()

 * retry when open() raises Errno 22 which means that the server has not
   called DisconnectNamedPipe() yet

 * use os.{open,read,write,close}() because self._pipe.read() raises
   IOError: [Errno 0] on Python 2

follow-up to ploxiln/paramiko-ng#134

port of paramiko/paramiko#2010