### PR TITLE
channel: prevent infinite loop sending closed channel

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -828,6 +828,7 @@ class Channel (ClosingContextManager):
         m.add_int(1)
         return self._send(s, m)
 
+    @open_only
     def sendall(self, s):
         """
         Send data to the channel, without allowing partial results.  Unlike
@@ -851,6 +852,7 @@ class Channel (ClosingContextManager):
             s = s[sent:]
         return None
 
+    @open_only
     def sendall_stderr(self, s):
         """
         Send data to the channel's "stderr" stream, without allowing partial


### PR DESCRIPTION
Both sendall and sendall_stderr call send inside a loop and use its result to advance their buffer. If the channel is closed, send returns 0 which causes both sendall methods to go into an infinite loop. Prevent this from occurring by using the open_only decorator.

I'm not sure this is the best fix since I haven't verified whether the channel can be closed after the sending begins. If so, then both sendall routines should instead raise an exception if send returns 0.