### PR TITLE
demos: fix TypeError in interactive shell on Windows

### DIFF
--- a/demos/interactive.py
+++ b/demos/interactive.py
@@ -81,7 +81,7 @@ def windows_shell(chan):
                 sys.stdout.write('\r\n*** EOF ***\r\n\r\n')
                 sys.stdout.flush()
                 break
-            sys.stdout.write(data)
+            sys.stdout.write(data.decode('utf-8'))
             sys.stdout.flush()
 
     writer = threading.Thread(target=writeall, args=(chan,))


### PR DESCRIPTION
TypeError: write() argument must be str, not byte

port of https://github.com/paramiko/paramiko/pull/2098