### PR TITLE
improve performance by calling Message.asbytes() directly

### DIFF
--- a/paramiko/packet.py
+++ b/paramiko/packet.py
@@ -30,8 +30,7 @@ from hmac import HMAC
 
 from paramiko import util
 from paramiko.common import (
-    linefeed_byte, cr_byte_value, asbytes, MSG_NAMES, DEBUG, xffffffff,
-    zero_byte,
+    linefeed_byte, cr_byte_value, MSG_NAMES, DEBUG, xffffffff, zero_byte,
 )
 from paramiko.py3compat import u, byte_ord
 from paramiko.ssh_exception import SSHException, ProxyCommandFailure
@@ -370,7 +369,7 @@ class Packetizer (object):
         Write a block of data using the current cipher, as an SSH block.
         """
         # encrypt this sucka
-        data = asbytes(data)
+        data = data.asbytes()
         cmd = byte_ord(data[0])
         if cmd in MSG_NAMES:
             cmd_name = MSG_NAMES[cmd]

--- a/paramiko/sftp.py
+++ b/paramiko/sftp.py
@@ -20,7 +20,7 @@ import socket
 import struct
 
 from paramiko import util
-from paramiko.common import asbytes, DEBUG
+from paramiko.common import DEBUG
 from paramiko.message import Message
 from paramiko.py3compat import byte_chr, byte_ord
 
@@ -102,7 +102,9 @@ class BaseSFTP (object):
     # ...internals...
 
     def _send_version(self):
-        self._send_packet(CMD_INIT, struct.pack('>I', _VERSION))
+        m = Message()
+        m.add_int(_VERSION)
+        self._send_packet(CMD_INIT, m)
         t, data = self._read_packet()
         if t != CMD_VERSION:
             raise SFTPError('Incompatible sftp protocol')
@@ -165,7 +167,7 @@ class BaseSFTP (object):
         return out
 
     def _send_packet(self, t, packet):
-        packet = asbytes(packet)
+        packet = packet.asbytes()
         out = struct.pack('>I', len(packet) + 1) + byte_chr(t) + packet
         if self.ultra_debug:
             self._loglist(DEBUG, util.format_binary(out, 'OUT: '))


### PR DESCRIPTION
Type-switch based code is used to convert a value to bytes. However, in all cases (except for one, fixed in this PR), the caller is specifying a Message instance. We can make this code much simpler by directly calling the correct method on Message.

(This might not have as large an effect on this fork as on upstream, because this fork doesn't use try/except for type check in asbytes() helper.)

port of https://github.com/paramiko/paramiko/pull/2165